### PR TITLE
Fix longitudes for astronomical data

### DIFF
--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -654,7 +654,7 @@ namespace wwtlib
                                 }
                                 if (bufferIsFlat)
                                 {
-                                 //   Xcoord += 180;
+                                    Xcoord += 180;
                                 }
                                 
                             }


### PR DESCRIPTION
While playing with the spreadsheet layer class, I found that it does not do the +=180 correction for longitudes when in astronomical mode. I found that this code does exist but was simply commented out. I think this should be uncommented to work properly (otherwise RA values I pass are offset by 180 degrees/12 hours). Is there a reason this was commented out?