### PR TITLE
Only re-assign RaUnits if in SpreadSheetLayer.LoadFromString when not updating

### DIFF
--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -1297,18 +1297,19 @@ namespace wwtlib
             table.LoadFromString(data, isUpdate, purgeAll, hasHeader);
             if (!isUpdate)
             {
+
                 GuessHeaderAssignments();
-            }
 
-            if (astronomical && lngColumn > -1)
-            {
-                double max = GetMaxValue(lngColumn);
-                if (max > 24)
+                if (astronomical && lngColumn > -1)
                 {
-                    RaUnits = RAUnits.Degrees;
+                    double max = GetMaxValue(lngColumn);
+                    if (max > 24)
+                    {
+                        RaUnits = RAUnits.Degrees;
+                    }
                 }
-            }
 
+            }
 
             if (purgeOld)
             {


### PR DESCRIPTION
I ran into an issue when using LoadFromString for spreadsheet layers to update the data - in this case, the code sometimes reset the RA units. However I believe this should only happen if isUpdate is False, as for guessing the header assignments.

I'm not set up to compile/use the C# code locally, so this change is untested (but I made the same change in the generated JS and it worked)