### PR TITLE
webclient/Global.asax: remove last references to WURFL

### DIFF
--- a/webclient/Global.asax
+++ b/webclient/Global.asax
@@ -1,17 +1,8 @@
 ﻿<%@ Application Language="C#" %>
-<%@ Import Namespace="WURFL" %>
-<%@ Import Namespace="WURFL.Config" %>
 
 <script runat="server">
-	public const String WurflDataFilePath = "./App_Data/wurfl-latest.zip";
 	void Application_Start(object sender, EventArgs e) 
 	{
-		var wurflDataFile = HttpContext.Current.Server.MapPath(WurflDataFilePath);
-
-		var configurer = new InMemoryConfigurer()
-			.MainFile(wurflDataFile);
-		WURFLManagerBuilder.Build(configurer);
-
 	}
 	
 	void Application_End(object sender, EventArgs e) 


### PR DESCRIPTION
If I don't take out these pieces, the server refuses to run due to an out-of-date or missing WURFL XML data file.