### PR TITLE
Added kpc as a valid unit in layers

### DIFF
--- a/HTML5SDK/wwtlib/Layers/Layer.cs
+++ b/HTML5SDK/wwtlib/Layers/Layer.cs
@@ -21,7 +21,7 @@ namespace wwtlib
 
 
 
-    public enum AltUnits { Meters=1, Feet=2, Inches=3, Miles=4, Kilometers=5, AstronomicalUnits=6, LightYears=7, Parsecs=8, MegaParsecs=9, Custom=10 };
+    public enum AltUnits { Meters=1, Feet=2, Inches=3, Miles=4, Kilometers=5, AstronomicalUnits=6, LightYears=7, Parsecs=8, MegaParsecs=9, Custom=10 , KiloParsecs=11};
     public enum FadeType { FadeIn=1, FadeOut=2, Both=3, None=4 };
     public abstract class Layer 
     {

--- a/HTML5SDK/wwtlib/Layers/ReferenceFrame.cs
+++ b/HTML5SDK/wwtlib/Layers/ReferenceFrame.cs
@@ -705,6 +705,9 @@ namespace wwtlib
                 case AltUnits.Parsecs:
                     scaleFactor = UiTools.AuPerParsec * UiTools.KilometersPerAu * 1000;
                     break;
+                case AltUnits.KiloParsecs:
+                    scaleFactor = UiTools.AuPerParsec * UiTools.KilometersPerAu * 1000 * 1000;
+                    break;
                 case AltUnits.MegaParsecs:
                     scaleFactor = UiTools.AuPerParsec * UiTools.KilometersPerAu * 1000 * 1000000;
                     break;

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -1194,6 +1194,9 @@ namespace wwtlib
                 case AltUnits.Parsecs:
                     factor = 1000 * UiTools.KilometersPerAu * UiTools.AuPerParsec;
                     break;
+                case AltUnits.KiloParsecs:
+                    factor = 1000 * UiTools.KilometersPerAu * UiTools.AuPerParsec * 1000;
+                    break;
                 case AltUnits.MegaParsecs:
                     factor = 1000 * UiTools.KilometersPerAu * UiTools.AuPerParsec * 1000000;
                     break;

--- a/HTML5SDK/wwtlib/Layers/TimeSeriesLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/TimeSeriesLayer.cs
@@ -238,6 +238,9 @@ namespace wwtlib
                 case "Parsecs":
                     AltUnit = AltUnits.Parsecs;
                     break;
+                case "KiloParsecs":
+                    AltUnit = AltUnits.KiloParsecs;
+                    break;
                 case "MegaParsecs":
                     AltUnit = AltUnits.MegaParsecs;
                     break;

--- a/HTML5SDK/wwtlib/Layers/VoTableLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/VoTableLayer.cs
@@ -215,6 +215,9 @@ namespace wwtlib
                 case "Parsecs":
                     AltUnit = AltUnits.Parsecs;
                     break;
+                case "KiloParsecs":
+                    AltUnit = AltUnits.KiloParsecs;
+                    break;
                 case "MegaParsecs":
                     AltUnit = AltUnits.MegaParsecs;
                     break;


### PR DESCRIPTION
This is useful for Galactic Astronomy. I thought it would be safer to add it as unit 11 rather than renumber the units in case anyone has hard-coded the units in a ``set_altUnit`` call.