### PR TITLE
Remove duplicate draw

### DIFF
--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -2219,8 +2219,6 @@ namespace wwtlib
                         break;
                 }
 
-
-                pointList.Draw(renderContext, opacity * Opacity, false);
             }
 
             if (lineList != null)


### PR DESCRIPTION
I haven't had a chance to check that this works (will do once the build SDK is available in this PR) but I think this duplicate draw might explain the overlap of shapes and gaussians in https://github.com/WorldWideTelescope/wwt-web-client/issues/191