### PR TITLE
Fix bug related to sizes array

### DIFF
--- a/HTML5SDK/wwtlib/Graphics/Primatives3d.cs
+++ b/HTML5SDK/wwtlib/Graphics/Primatives3d.cs
@@ -869,6 +869,7 @@ namespace wwtlib
             colors.Clear();
             points.Clear();
             dates.Clear();
+            sizes.Clear();
             EmptyPointBuffer();
 
         }


### PR DESCRIPTION
This fixes a bug that caused ``set_sizeColumn`` to not have any effect. Essentially the sizes array 
 in pointList was never emptied, so that the original sizes were always used.

Fixes https://github.com/WorldWideTelescope/wwt-web-client/issues/203