### PR TITLE
Set dirty=true in UpdateData to make sure visualization is updated

### DIFF
--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -176,6 +176,7 @@ namespace wwtlib
             LoadFromString(data as string, true, purgeOld, purgeAll, hasHeader);
             ComputeDateDomainRange(-1, -1);
             dataDirty = true;
+            dirty = true;
             return true;
         }
 


### PR DESCRIPTION
It looks like this is needed to properly fix https://github.com/WorldWideTelescope/wwt-web-client/issues/192 (i.e. setting dataDirty is not enough).