### PR TITLE
Fix xyzScale if we are in astronomical mode

### DIFF
--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -679,7 +679,16 @@ namespace wwtlib
                         }
                         else if (this.CoordinatesType == CoordinatesTypes.Rectangular)
                         {
-                            double xyzScale = GetScaleFactor(CartesianScale, CartesianCustomScale) / meanRadius;
+                            double xyzScale = GetScaleFactor(CartesianScale, CartesianCustomScale);
+
+                            if (astronomical)
+                            {
+                                factor /= (1000 * UiTools.KilometersPerAu);
+                            }
+                            else
+                            {
+                                factor /= meanRadius;
+                            }
 
                             if (ZAxisColumn > -1)
                             {

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -683,11 +683,11 @@ namespace wwtlib
 
                             if (astronomical)
                             {
-                                factor /= (1000 * UiTools.KilometersPerAu);
+                                xyzScale /= (1000 * UiTools.KilometersPerAu);
                             }
                             else
                             {
-                                factor /= meanRadius;
+                                xyzScale /= meanRadius;
                             }
 
                             if (ZAxisColumn > -1)


### PR DESCRIPTION
This fixes an asymmetry that if we are in astronomical mode, we should have the same behavior for cartesian and spherical coordinates for scaling the coordinates, otherwise the markers appear at larger distances from the sun than they should.