### PR TITLE
Try and fix scaling by mean radius

### DIFF
--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -564,9 +564,7 @@ namespace wwtlib
             Dictionary<string, bool> selectDomain = new Dictionary<string, bool>();
 
 
-            double mr = 0;
-
-        //    double mr = LayerManager.AllMaps[ReferenceFrame].Frame.MeanRadius;
+            double mr = LayerManager.AllMaps[ReferenceFrame].Frame.MeanRadius;
             if (mr != 0)
             {
                 meanRadius = mr;


### PR DESCRIPTION
As described in https://github.com/WorldWideTelescope/wwt-web-client/issues/189, for spreadsheet layers the positions are currently not scaled by the right value if not centered on the earth. It looks like there is actual code that was commented out that appears to do the right thing, so just testing if this works (opening the PR to build the JS SDK easily).