### PR TITLE
Potential Fix for issue 199

### DIFF
--- a/HTML5SDK/wwtlib/RenderContext.cs
+++ b/HTML5SDK/wwtlib/RenderContext.cs
@@ -284,8 +284,8 @@ namespace wwtlib
                 backgroundImageset = value;
                 if (viewModeChanged) //Prevent potential artifacts when going from 3D to Sky/Pan
                 {
+                    WWTControl.Singleton.FreezeView();
                     WWTControl.Singleton.ClampZooms(this);
-                    WWTControl.Singleton.Mover = null;
                 }
             }
         }

--- a/HTML5SDK/wwtlib/RenderContext.cs
+++ b/HTML5SDK/wwtlib/RenderContext.cs
@@ -278,7 +278,16 @@ namespace wwtlib
         public Imageset BackgroundImageset
         {
             get { return backgroundImageset; }
-            set { backgroundImageset = value; }
+            set
+            {
+                bool viewModeChanged = backgroundImageset != null && value != null && (backgroundImageset.DataSetType != value.DataSetType);
+                backgroundImageset = value;
+                if (viewModeChanged) //Prevent potential artifacts when going from 3D to Sky/Pan
+                {
+                    WWTControl.Singleton.ClampZooms(this);
+                    WWTControl.Singleton.Mover = null;
+                }
+            }
         }
 
         Imageset foregroundImageset;
@@ -1292,7 +1301,7 @@ namespace wwtlib
 
             TargetCamera = ViewCamera.Copy();
         }
-
+    
         internal void SetVertexBuffer(VertexBufferBase vertexBuffer)
         {
         }

--- a/HTML5SDK/wwtlib/WWTControl.cs
+++ b/HTML5SDK/wwtlib/WWTControl.cs
@@ -2885,6 +2885,13 @@ namespace wwtlib
             image.Src = Singleton.Canvas.GetDataUrl();
 
         }
+
+        public void ClampZooms(RenderContext rc)
+        {
+            rc.ViewCamera.Zoom = DoubleUtilities.Clamp(rc.ViewCamera.Zoom, ZoomMin, ZoomMax);
+            rc.TargetCamera.Zoom = DoubleUtilities.Clamp(rc.TargetCamera.Zoom, ZoomMin, ZoomMax);
+        }
+
     }
     public delegate void BlobReady(System.Html.Data.Files.Blob blob);
 


### PR DESCRIPTION
#199 Weird visual effects when switching from 3D to Sky view.

In 3D mode, the `Zoom` property of the camera represents the distance of the camera from the Sun or tracked object. In Sky mode the `Zoom` is a proxy for the field of view, and the projection matrix breaks down when the field of view is too big. 

This fix just makes sure that when we change view modes, we stop any in-progress movers and make sure the view and target camera `Zoom` values are in the valid range.