### PR TITLE
Fix issues with FITS loading

### DIFF
--- a/HTML5SDK/wwtlib/Layers/FitsImage.cs
+++ b/HTML5SDK/wwtlib/Layers/FitsImage.cs
@@ -122,7 +122,7 @@ namespace wwtlib
 
 
 
-            while (!foundEnd)
+            while (!foundEnd && !br.EndOfStream)
             {
                 for (int i = 0; i < 36; i++)
                 {

--- a/HTML5SDK/wwtlib/Utilities/BinaryReader.cs
+++ b/HTML5SDK/wwtlib/Utilities/BinaryReader.cs
@@ -31,6 +31,11 @@ namespace wwtlib
             get { return data.length; }
         }
 
+        public bool EndOfStream
+        {
+            get { return position >= Length; }
+        }
+
         public BinaryReader(Uint8Array arraybuf)
         {
             data = arraybuf;

--- a/webclient/controllers/modals/OpenItemController.js
+++ b/webclient/controllers/modals/OpenItemController.js
@@ -64,6 +64,7 @@
           console.timeEnd('openLocal: ' + type);
           $scope.openItemUrl = mediaResult.url;
           $scope.openItem();
+          $('#addFileReset')[0].reset();
         });
       };
 

--- a/webclient/views/modals/open-item.html
+++ b/webclient/views/modals/open-item.html
@@ -25,7 +25,9 @@
         <div ng-if="openType != 'image'">
           <p localize="Or"></p>
           <a class="btn" localize="Choose local file" href="#" onclick="$('#addFile')[0].click()"/>
-          <input type="file" id="addFile" onchange="angular.element(this).scope().mediaFileChange(event)"/>
+          <form id="addFileReset">
+            <input type="file" id="addFile" onchange="angular.element(this).scope().mediaFileChange(event)"/>
+          </form>
         </div>
 
         <div ng-show="imageFail">


### PR DESCRIPTION
This PR addresses an issue where trying to load the same FITS file twice or a non-FITS file as a FITS file would cause the web client to freeze. Now loading the same FITS file twice will work as expected and trying to load a non-FITS file will result in a warning being show to the user. There has been some discussion with @pkgw about alternatives to using the JavaScript alert in the backend, but implementing that is beyond the scope of this PR.