### PR TITLE
Enable loading of 64-bit float FITS

### DIFF
--- a/HTML5SDK/wwtlib/Layers/FitsImage.cs
+++ b/HTML5SDK/wwtlib/Layers/FitsImage.cs
@@ -673,30 +673,30 @@ namespace wwtlib
 
         private void InitDataDouble(BinaryReader br)
         {
-            //double[] buffer = new double[BufferSize];
-            //Uint8Array part = new Uint8Array(4);
-            //DataBuffer = buffer;
-            //for (int i = 0; i < BufferSize; i++)
-            //{
-            //    part[7] = br.ReadByte();
-            //    part[6] = br.ReadByte();
-            //    part[5] = br.ReadByte();
-            //    part[4] = br.ReadByte();
-            //    part[3] = br.ReadByte();
-            //    part[2] = br.ReadByte();
-            //    part[1] = br.ReadByte();
-            //    part[0] = br.ReadByte();
-            //    buffer[i] = buffer[i] = (new Float64Array(part.buffer, 0, 1))[0];
+            double[] buffer = new double[BufferSize];
+            Uint8Array part = new Uint8Array(8);
+            DataBuffer = buffer;
+            for (int i = 0; i < BufferSize; i++)
+            {
+                part[7] = br.ReadByte();
+                part[6] = br.ReadByte();
+                part[5] = br.ReadByte();
+                part[4] = br.ReadByte();
+                part[3] = br.ReadByte();
+                part[2] = br.ReadByte();
+                part[1] = br.ReadByte();
+                part[0] = br.ReadByte();
+                buffer[i] = (new Float64Array(part.buffer, 0, 1))[0];
 
-            //    if (MinVal > (double)buffer[i])
-            //    {
-            //        MinVal = (double)buffer[i];
-            //    }
-            //    if (MaxVal < (double)buffer[i])
-            //    {
-            //        MaxVal = (double)buffer[i];
-            //    }
-            //}
+                if (MinVal > (double)buffer[i])
+                {
+                    MinVal = (double)buffer[i];
+                }
+                if (MaxVal < (double)buffer[i])
+                {
+                    MaxVal = (double)buffer[i];
+                }
+            }
         }
         public ScaleTypes lastScale = ScaleTypes.Linear;
         public double lastBitmapMin = 0;

--- a/HTML5SDK/wwtlib/WebGL.cs
+++ b/HTML5SDK/wwtlib/WebGL.cs
@@ -818,6 +818,22 @@ namespace System.Html
 
     [ScriptIgnoreNamespace]
     [ScriptImport]
+    public class Float64Array
+    {
+        public Float64Array(object data) { }
+        public Float64Array(object data, int a, int b) { }
+        [ScriptField]
+        public int length { get { return 0; } }
+
+        [ScriptField]
+        public double this[int key]
+        {
+            get { return 0; }
+        }
+    }
+
+    [ScriptIgnoreNamespace]
+    [ScriptImport]
     public class Uint8Array
     {
         public Uint8Array(object data) { }


### PR DESCRIPTION
Addresses #220. I uncommented the code and added the methods needed for the 64FloatArray in C#. I tested with the FITS files in #202 (with some jitteriness due to precision issues but that is a bigger scope than this PR).