### PR TITLE
Quick fix for hyperlinked text/images in tours

### DIFF
--- a/HTML5SDK/wwtlib/Tours/TourPlayer.cs
+++ b/HTML5SDK/wwtlib/Tours/TourPlayer.cs
@@ -844,7 +844,7 @@ namespace wwtlib
                     if (!string.IsNullOrEmpty(tour.CurrentTourStop.Overlays[i].Url))
                     {
                         Overlay linkItem = tour.CurrentTourStop.Overlays[i];
-                        Util.OpenUrl(linkItem.Url, true);
+                        Util.OpenUrl(linkItem.Url);
                         return true;
                     }
                     if (!string.IsNullOrEmpty(tour.CurrentTourStop.Overlays[i].LinkID))

--- a/HTML5SDK/wwtlib/Util.cs
+++ b/HTML5SDK/wwtlib/Util.cs
@@ -336,9 +336,9 @@ namespace wwtlib
             return val;
 
         }
-        internal static void OpenUrl(string p, bool p_2)
+        internal static void OpenUrl(string url)
         {
-            //todo implement this by opening new window in HTML
+            Window.Open(url);
         }
 
 


### PR DESCRIPTION
Quick implementation of the OpenUrl method in the Utils files. This can be caught by the popup blocker.