### PR TITLE
Add support for normalization of point sizes

### DIFF
--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -190,8 +190,8 @@ namespace wwtlib
 
                 // The __normalized_size__ column is only present for backward-compatibility
                 // and should be removed in this version of SpreadSheetLayer
-                if (table.Header.IndexOf("__normalized_size__") > -1) {
-                    table.RemoveColumn("__normalized_size__");
+                if (table.Header.IndexOf(NormalizeSizeColumnName) > -1) {
+                    table.RemoveColumn(NormalizeSizeColumnName);
                 }
 
                 ComputeDateDomainRange(-1, -1);
@@ -229,7 +229,7 @@ namespace wwtlib
                 foreach (string[] row in table_copy.Rows) {
                     normalizedPointSize.Add(NormalizePointSize(Single.Parse(row[sizeColumn])).ToString());
                 }
-                table_copy.AddColumn("__normalized_size__", normalizedPointSize);
+                table_copy.AddColumn(NormalizeSizeColumnName, normalizedPointSize);
                 data = table_copy.Save();
             } else {
                 data = table.Save();
@@ -1432,7 +1432,7 @@ namespace wwtlib
             // detect normalization arguments when reading in the XML, we switch
             // sizeColumn to the original one.
             if (sizeColumn > -1 && NormalizeSize) {
-                xmlWriter.WriteAttributeString("SizeColumn", table.Header.IndexOf("__normalized_size__").ToString());
+                xmlWriter.WriteAttributeString("SizeColumn", table.Header.IndexOf(NormalizeSizeColumnName).ToString());
                 xmlWriter.WriteAttributeString("NormalizeColumn", sizeColumn.ToString());
                 xmlWriter.WriteAttributeString("NormalizeSize", NormalizeSize.ToString());
                 xmlWriter.WriteAttributeString("NormalizeSizeClip", NormalizeSizeClip.ToString());
@@ -2098,6 +2098,10 @@ namespace wwtlib
         // The NormalizeSizeClip attribute can be used to determine whether the sizes should
         // be clipped to the range [0:1]. At this time, normalization is only applied if
         // PointScaleTypes is Linear or Power.
+
+        // Note that we use a hard-coded UUID since we need it to always be the same across
+        // all WWT sessions so that we can remove it when it isn't needed.
+        private string NormalizeSizeColumnName = "dfe78b4c-f972-4796-b04f-68c5efd4ecb0";
 
         protected bool normalizeSize = false;
 

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -222,16 +222,17 @@ namespace wwtlib
             // approach we take is to add a column with the computed sizes for versions of
             // WWT that can't do the dynamic scaling - while in newer versions we ignore
             // this additional column and use the dynamic scaling.
+            string data = "";
             if (sizeColumn > -1 && NormalizeSize) {
                 Table table_copy = table.Clone();
                 List<string> normalizedPointSize = new List<string>();
                 foreach (string[] row in table_copy.Rows) {
-                    normalizedPointSize.Add(NormalizePointSize(row[sizeColumn]).ToString());
+                    normalizedPointSize.Add(NormalizePointSize(Single.Parse(row[sizeColumn])).ToString());
                 }
                 table_copy.AddColumn("__normalized_size__", normalizedPointSize);
-                string data = table_copy.Save();
+                data = table_copy.Save();
             } else {
-                string data = table.Save();
+                data = table.Save();
             }
 
             Blob blob = new Blob(new object[] { data });

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -2103,28 +2103,21 @@ namespace wwtlib
         public float NormalizePointSize(float value)
         {
 
-            float new_value;
+            if (!NormalizeSize)
+                return value;
 
-            if(NormalizeSize)
+            float new_value = (value - NormalizeSizeMin) / (NormalizeSizeMax - NormalizeSizeMin);
+
+            if (NormalizeSizeClip)
             {
-                new_value = (value - NormalizeSizeMin) / (NormalizeSizeMax - NormalizeSizeMin);
-
-                if (NormalizeSizeClip)
+                if (new_value < 0)
                 {
-                    if (new_value < 0)
-                    {
-                        new_value = 0;
-                    }
-                    else if (new_value > 1)
-                    {
-                        new_value = 1;
-                    }
+                    new_value = 0;
                 }
-
-            }
-            else
-            {
-                new_value = value;
+                else if (new_value > 1)
+                {
+                    new_value = 1;
+                }
             }
 
             return new_value;

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -479,8 +479,6 @@ namespace wwtlib
         }
         double barScaleFactor = 20;
 
-
-
         private double meanRadius = 6371000;
 
         protected bool PrepVertexBuffer(RenderContext renderContext, float opacity)
@@ -759,13 +757,14 @@ namespace wwtlib
                             {
                                 case PointScaleTypes.Linear:
                                     pointSize = Single.Parse(row[sizeColumn]);
+                                    pointSize = NormalizePointSize(pointSize);
                                     break;
                                 case PointScaleTypes.Log:
-                                    pointSize = (float)Math.Log(Single.Parse(row[sizeColumn]));
+                                    pointSize = Single.Parse(row[sizeColumn]);
+                                    pointSize = (float)Math.Log(pointSize);
                                     break;
                                 case PointScaleTypes.Power:
                                     {
-                                        double size = 0;
 
                                         try
                                         {
@@ -2018,7 +2017,6 @@ namespace wwtlib
 
         protected int sizeColumn = -1;
 
-
         public int SizeColumn
         {
             get { return sizeColumn; }
@@ -2031,6 +2029,108 @@ namespace wwtlib
                 }
             }
         }
+
+        // The following attributes control whether the point sizes should be normalized before
+        // being used. When NormalizeSize is true, the point sizes are scaled using
+        //
+        // new_size = (size - NormalizeSizeMin) / (NormalizeSizeMax - NormalizeSizeMin)
+        //
+        // The NormalizeSizeClip attribute can be used to determine whether the sizes should
+        // be clipped to the range [0:1]. At this time, normalization is only applied if
+        // PointScaleTypes is Linear.
+
+        protected bool normalizeSize = false;
+
+        public bool NormalizeSize
+        {
+            get { return normalizeSize; }
+            set
+            {
+                if (normalizeSize != value)
+                {
+                    version++;
+                    normalizeSize = value;
+                }
+            }
+        }
+
+        protected bool normalizeSizeClip = false;
+
+        public bool NormalizeSizeClip
+        {
+            get { return normalizeSizeClip; }
+            set
+            {
+                if (normalizeSizeClip != value)
+                {
+                    version++;
+                    normalizeSizeClip = value;
+                }
+            }
+        }
+
+        protected float normalizeSizeMin = 0;
+
+        public float NormalizeSizeMin
+        {
+            get { return normalizeSizeMin; }
+            set
+            {
+                if (normalizeSizeMin != value)
+                {
+                    version++;
+                    normalizeSizeMin = value;
+                }
+            }
+        }
+
+        protected float normalizeSizeMax = 1;
+
+        public float NormalizeSizeMax
+        {
+            get { return normalizeSizeMax; }
+            set
+            {
+                if (normalizeSizeMax != value)
+                {
+                    version++;
+                    normalizeSizeMax = value;
+                }
+            }
+        }
+
+        public float NormalizePointSize(float value)
+        {
+
+            float new_value;
+
+            if(NormalizeSize)
+            {
+                new_value = (value - NormalizeSizeMin) / (NormalizeSizeMax - NormalizeSizeMin);
+
+                if (NormalizeSizeClip)
+                {
+                    if (new_value < 0)
+                    {
+                        new_value = 0;
+                    }
+                    else if (new_value > 1)
+                    {
+                        new_value = 1;
+                    }
+                }
+
+            }
+            else
+            {
+                new_value = value;
+            }
+
+            return new_value;
+
+        }
+
+
         protected int nameColumn = 0;
 
 

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -768,7 +768,8 @@ namespace wwtlib
 
                                         try
                                         {
-                                            pointSize = (float)double.Parse(row[sizeColumn]);
+                                            pointSize = Single.Parse(row[sizeColumn]);
+                                            pointSize = NormalizePointSize(pointSize);
                                             pointSize = Math.Pow(2, pointSize);
                                         }
                                         catch
@@ -2037,7 +2038,7 @@ namespace wwtlib
         //
         // The NormalizeSizeClip attribute can be used to determine whether the sizes should
         // be clipped to the range [0:1]. At this time, normalization is only applied if
-        // PointScaleTypes is Linear.
+        // PointScaleTypes is Linear or Power.
 
         protected bool normalizeSize = false;
 

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -233,7 +233,7 @@ namespace wwtlib
                 }
                 table_copy.AddColumn(NormalizeSizeColumnName, normalizedPointSize);
                 data = table_copy.Save();
-                lastNormalizeSizeColumnIndex = table_copy.Headers.Count - 1;
+                lastNormalizeSizeColumnIndex = table_copy.Header.Count - 1;
             } else {
                 data = table.Save();
                 lastNormalizeSizeColumnIndex = -1;

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -188,8 +188,9 @@ namespace wwtlib
             {
                 table.LoadFromString(data, false, true, true);
 
-                // The __normalized_size__ column is only present for backward-compatibility
-                // and should be removed in this version of SpreadSheetLayer
+                // The NormalizeSizeColumnName column is only present for backward-compatibility
+                // and should be removed in this version of SpreadSheetLayer, otherwise we might
+                // keep adding it several times if exporting to XML again.
                 if (table.Header.IndexOf(NormalizeSizeColumnName) > -1) {
                     table.RemoveColumn(NormalizeSizeColumnName);
                 }
@@ -216,7 +217,7 @@ namespace wwtlib
 
             string dir = fileName.Substring(0, fileName.LastIndexOf("\\"));
 
-            // In this SpreadSheetLayer we implement dynamic normalization of the points
+            // In this this layer class we implement dynamic normalization of the points
             // based on one of the existing numerical columns. However, we need to produce
             // XML files that are backward-compatible with older versions of WWT, so the
             // approach we take is to add a column with the computed sizes for versions of
@@ -1424,7 +1425,7 @@ namespace wwtlib
             xmlWriter.WriteAttributeString("StartDateColumn", StartDateColumn.ToString());
             xmlWriter.WriteAttributeString("EndDateColumn", EndDateColumn.ToString());
 
-            // In this SpreadSheetLayer we implement dynamic normalization of the points
+            // In this layer class we implement dynamic normalization of the points
             // based on one of the existing numerical columns. However, we need to produce
             // XML files that are backward-compatible with older versions of WWT. If
             // normalization is used, we therefore point sizeColumn to the hard-coded
@@ -1587,7 +1588,7 @@ namespace wwtlib
             StartDateColumn = int.Parse(node.Attributes.GetNamedItem("StartDateColumn").Value);
             EndDateColumn = int.Parse(node.Attributes.GetNamedItem("EndDateColumn").Value);
 
-            // In this SpreadSheetLayer we implement dynamic normalization of the points
+            // In this layer class we implement dynamic normalization of the points
             // based on one of the existing numerical columns. However, we need to produce
             // XML files that are backward-compatible with older versions of WWT.
             // Since we can deal with normalization here, we ignore SizeColumn and use

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -209,6 +209,7 @@ namespace wwtlib
 
         string fileName;
 
+        private int lastNormalizeSizeColumnIndex = -1;
 
         public override void AddFilesToCabinet(FileCabinet fc)
         {
@@ -232,8 +233,10 @@ namespace wwtlib
                 }
                 table_copy.AddColumn(NormalizeSizeColumnName, normalizedPointSize);
                 data = table_copy.Save();
+                lastNormalizeSizeColumnIndex = table_copy.Headers.Count - 1;
             } else {
                 data = table.Save();
+                lastNormalizeSizeColumnIndex = -1;
             }
 
             Blob blob = new Blob(new object[] { data });
@@ -1432,12 +1435,12 @@ namespace wwtlib
             // normalized sizes that we compute in AddFilesToCabinet, and then if we
             // detect normalization arguments when reading in the XML, we switch
             // sizeColumn to the original one.
-            if (sizeColumn > -1 && NormalizeSize) {
+            if (lastNormalizeSizeColumnIndex > -1) {
                 // Note that here we assume that the added column with the dynamic sizes is
                 // the next one along in the table - we don't actually modify the table
                 // in the layer hence why we have to assume this (we just make a copy when
                 // writing out).
-                xmlWriter.WriteAttributeString("SizeColumn", table.Header.Count.ToString());
+                xmlWriter.WriteAttributeString("SizeColumn", lastNormalizeSizeColumnIndex);
                 xmlWriter.WriteAttributeString("NormalizeColumn", sizeColumn.ToString());
             } else {
                 xmlWriter.WriteAttributeString("SizeColumn", SizeColumn.ToString());

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -1433,7 +1433,11 @@ namespace wwtlib
             // detect normalization arguments when reading in the XML, we switch
             // sizeColumn to the original one.
             if (sizeColumn > -1 && NormalizeSize) {
-                xmlWriter.WriteAttributeString("SizeColumn", table.Header.IndexOf(NormalizeSizeColumnName).ToString());
+                // Note that here we assume that the added column with the dynamic sizes is
+                // the next one along in the table - we don't actually modify the table
+                // in the layer hence why we have to assume this (we just make a copy when
+                // writing out).
+                xmlWriter.WriteAttributeString("SizeColumn", table.Header.Count.ToString());
                 xmlWriter.WriteAttributeString("NormalizeColumn", sizeColumn.ToString());
             } else {
                 xmlWriter.WriteAttributeString("SizeColumn", SizeColumn.ToString());

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -1434,13 +1434,14 @@ namespace wwtlib
             if (sizeColumn > -1 && NormalizeSize) {
                 xmlWriter.WriteAttributeString("SizeColumn", table.Header.IndexOf(NormalizeSizeColumnName).ToString());
                 xmlWriter.WriteAttributeString("NormalizeColumn", sizeColumn.ToString());
-                xmlWriter.WriteAttributeString("NormalizeSize", NormalizeSize.ToString());
-                xmlWriter.WriteAttributeString("NormalizeSizeClip", NormalizeSizeClip.ToString());
-                xmlWriter.WriteAttributeString("NormalizeSizeMin", NormalizeSizeMin.ToString());
-                xmlWriter.WriteAttributeString("NormalizeSizeMax", NormalizeSizeMax.ToString());
             } else {
                 xmlWriter.WriteAttributeString("SizeColumn", SizeColumn.ToString());
             }
+
+            xmlWriter.WriteAttributeString("NormalizeSize", NormalizeSize.ToString());
+            xmlWriter.WriteAttributeString("NormalizeSizeClip", NormalizeSizeClip.ToString());
+            xmlWriter.WriteAttributeString("NormalizeSizeMin", NormalizeSizeMin.ToString());
+            xmlWriter.WriteAttributeString("NormalizeSizeMax", NormalizeSizeMax.ToString());
 
             xmlWriter.WriteAttributeString("HyperlinkFormat", HyperlinkFormat.ToString());
             xmlWriter.WriteAttributeString("HyperlinkColumn", HyperlinkColumn.ToString());
@@ -1595,12 +1596,16 @@ namespace wwtlib
             if (node.Attributes.GetNamedItem("NormalizeColumn") != null)
             {
                 SizeColumn = int.Parse(node.Attributes.GetNamedItem("NormalizeColumn").Value);
+            } else {
+                SizeColumn = int.Parse(node.Attributes.GetNamedItem("SizeColumn").Value);
+            }
+
+            if (node.Attributes.GetNamedItem("NormalizeSize") != null)
+            {
                 NormalizeSize = Boolean.Parse(node.Attributes.GetNamedItem("NormalizeSize").Value);
                 NormalizeSizeClip = Boolean.Parse(node.Attributes.GetNamedItem("NormalizeSizeClip").Value);
                 NormalizeSizeMin = float.Parse(node.Attributes.GetNamedItem("NormalizeSizeMin").Value);
                 NormalizeSizeMax = float.Parse(node.Attributes.GetNamedItem("NormalizeSizeMax").Value);
-            } else {
-                SizeColumn = int.Parse(node.Attributes.GetNamedItem("SizeColumn").Value);
             }
 
             HyperlinkFormat = node.Attributes.GetNamedItem("HyperlinkFormat").Value;

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -190,8 +190,8 @@ namespace wwtlib
 
                 // The __normalized_size__ column is only present for backward-compatibility
                 // and should be removed in this version of SpreadSheetLayer
-                if (table.Headers.IndexOf('__normalized_size__') > -1) {
-                    table.RemoveColumn('__normalized_size__');
+                if (table.Headers.IndexOf("__normalized_size__") > -1) {
+                    table.RemoveColumn("__normalized_size__");
                 }
 
                 ComputeDateDomainRange(-1, -1);
@@ -225,10 +225,10 @@ namespace wwtlib
             if (sizeColumn > -1 && NormalizeSize) {
                 Table table_copy = table.Clone();
                 normalizedPointSize = new List<string>();
-                for (string[] row in table_copy.Rows) {
+                foreach (string[] row in table_copy.Rows) {
                     normalizedPointSize.Add(NormalizePointSize(row[sizeColumn]));
                 }
-                table_copy.AddColumn('__normalized_size__', normalizedPointSize);
+                table_copy.AddColumn("__normalized_size__", normalizedPointSize);
             } else {
                 string data = table.Save();
             }
@@ -1432,7 +1432,7 @@ namespace wwtlib
             // detect normalization arguments when reading in the XML, we switch
             // sizeColumn to the original one.
             if (sizeColumn > -1 && NormalizeSize) {
-                xmlWriter.WriteAttributeString("SizeColumn", table.Header.IndexOf('__normalized_size__').ToString());
+                xmlWriter.WriteAttributeString("SizeColumn", table.Header.IndexOf("__normalized_size__").ToString());
                 xmlWriter.WriteAttributeString("NormalizeColumn", sizeColumn.ToString());
                 xmlWriter.WriteAttributeString("NormalizeSize", NormalizeSize.ToString());
                 xmlWriter.WriteAttributeString("NormalizeSizeClip", NormalizeSizeClip.ToString());
@@ -1599,7 +1599,7 @@ namespace wwtlib
                 NormalizeSizeClip = Boolean.Parse(node.Attributes.GetNamedItem("NormalizeSizeClip").Value);
                 NormalizeSizeMin = float.Parse(node.Attributes.GetNamedItem("NormalizeSizeMin").Value);
                 NormalizeSizeMax = float.Parse(node.Attributes.GetNamedItem("NormalizeSizeMax").Value);
-x            } else {
+            } else {
                 SizeColumn = int.Parse(node.Attributes.GetNamedItem("SizeColumn").Value);
             }
 

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -190,7 +190,7 @@ namespace wwtlib
 
                 // The __normalized_size__ column is only present for backward-compatibility
                 // and should be removed in this version of SpreadSheetLayer
-                if (table.Headers.IndexOf("__normalized_size__") > -1) {
+                if (table.Header.IndexOf("__normalized_size__") > -1) {
                     table.RemoveColumn("__normalized_size__");
                 }
 
@@ -224,16 +224,15 @@ namespace wwtlib
             // this additional column and use the dynamic scaling.
             if (sizeColumn > -1 && NormalizeSize) {
                 Table table_copy = table.Clone();
-                normalizedPointSize = new List<string>();
+                List<string> normalizedPointSize = new List<string>();
                 foreach (string[] row in table_copy.Rows) {
-                    normalizedPointSize.Add(NormalizePointSize(row[sizeColumn]));
+                    normalizedPointSize.Add(NormalizePointSize(row[sizeColumn]).ToString());
                 }
                 table_copy.AddColumn("__normalized_size__", normalizedPointSize);
+                string data = table_copy.Save();
             } else {
                 string data = table.Save();
             }
-
-            string data = table.Save();
 
             Blob blob = new Blob(new object[] { data });
 

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -1589,7 +1589,7 @@ namespace wwtlib
 
             // In this SpreadSheetLayer we implement dynamic normalization of the points
             // based on one of the existing numerical columns. However, we need to produce
-            // XML files that are backward-compatible with older versions of WWT. 
+            // XML files that are backward-compatible with older versions of WWT.
             // Since we can deal with normalization here, we ignore SizeColumn and use
             // NormalizeColumn instead, if it is present.
 
@@ -1599,6 +1599,8 @@ namespace wwtlib
             } else {
                 SizeColumn = int.Parse(node.Attributes.GetNamedItem("SizeColumn").Value);
             }
+
+            // Only recent files have normalization parameters
 
             if (node.Attributes.GetNamedItem("NormalizeSize") != null)
             {

--- a/HTML5SDK/wwtlib/Layers/Table.cs
+++ b/HTML5SDK/wwtlib/Layers/Table.cs
@@ -311,10 +311,17 @@ namespace wwtlib
         public Table Clone()
         {
             Table cloned_table = new Table();
-            cloned_table.Header = new List<string>(Header);
-            for (int i = 0; i < Rows.Count; i++)
+            for (int i = 0; i < Header.Count; i++)
             {
-                cloned_table.Rows.Add(new List<string>(Rows[i]));
+                cloned_table.Header.Add(Header[i]);
+            }
+            for (int j = 0; j < Rows.Count; j++)
+            {
+                cloned_table.Rows.Add([]);
+                for (int i = 0; i < Rows[j].Count; i++)
+                {
+                    cloned_table.Rows[j].Add(Rows[j][i]);
+                }
             }
             return cloned_table;
         }

--- a/HTML5SDK/wwtlib/Layers/Table.cs
+++ b/HTML5SDK/wwtlib/Layers/Table.cs
@@ -318,7 +318,7 @@ namespace wwtlib
 
         public void addColumn(string name, List<string> data)
         {
-            Header.Add(name)
+            Header.Add(name);
             for (int i = 0; i < data.Count; i++)
             {
                 Rows[i].Add(data[i]);

--- a/HTML5SDK/wwtlib/Layers/Table.cs
+++ b/HTML5SDK/wwtlib/Layers/Table.cs
@@ -8,7 +8,7 @@ using System.Html.Media.Graphics;
 
 namespace wwtlib
 {
-    class Table
+    public class Table
     {
         public Table()
         {
@@ -284,10 +284,7 @@ namespace wwtlib
                 temp.Add(rowData);
                 count++;
             }
-            if (purge)
-            {
-                Rows = temp;
-            }
+            Rows = temp;
 
         }
 
@@ -307,5 +304,26 @@ namespace wwtlib
         //        count++;
         //    }
         //}
+
+        public Table Clone()
+        {
+            Table cloned_table = new Table();
+            cloned_table.Header = new List<string>(Header);
+            Rows.ForEach((item) =>
+                {
+                    cloned_table.Rows.Add(new List<string>(item));
+                });
+            return cloned_table;
+
+        }
+
+        public void addColumn(string name, List<string> data))
+        {
+            Header.Add(name)
+            for (int i = 0; i < data.Count; i++)
+            {
+                Rows[i].Add(data[i]);
+            }
+        }
     }
 }

--- a/HTML5SDK/wwtlib/Layers/Table.cs
+++ b/HTML5SDK/wwtlib/Layers/Table.cs
@@ -284,7 +284,10 @@ namespace wwtlib
                 temp.Add(rowData);
                 count++;
             }
-            Rows = temp;
+            if (purge)
+            {
+                Rows = temp;
+            }
 
         }
 

--- a/HTML5SDK/wwtlib/Layers/Table.cs
+++ b/HTML5SDK/wwtlib/Layers/Table.cs
@@ -309,15 +309,14 @@ namespace wwtlib
         {
             Table cloned_table = new Table();
             cloned_table.Header = new List<string>(Header);
-            Rows.ForEach((item) =>
-                {
-                    cloned_table.Rows.Add(new List<string>(item));
-                });
+            for (int i = 0; i < Rows.Count; i++)
+            {
+                cloned_table.Rows.Add(new List<string>(Rows[i]));
+            }
             return cloned_table;
-
         }
 
-        public void addColumn(string name, List<string> data))
+        public void addColumn(string name, List<string> data)
         {
             Header.Add(name)
             for (int i = 0; i < data.Count; i++)

--- a/HTML5SDK/wwtlib/Layers/Table.cs
+++ b/HTML5SDK/wwtlib/Layers/Table.cs
@@ -337,9 +337,11 @@ namespace wwtlib
 
         public void RemoveColumn(string name) {
             int remove_index = Header.IndexOf(name);
-            if (remove_index > -1) {
+            if (remove_index > -1)
+            {
                 Header.RemoveAt(remove_index);
                 for (int i = 0; i < Rows.Count; i++)
+                {
                     Rows[i].RemoveAt(remove_index);
                 }
             }

--- a/HTML5SDK/wwtlib/Layers/Table.cs
+++ b/HTML5SDK/wwtlib/Layers/Table.cs
@@ -339,8 +339,8 @@ namespace wwtlib
             int remove_index = Header.IndexOf(name);
             if (remove_index > -1) {
                 Header.RemoveAt(remove_index);
-                foreach (string[] row in Rows) {
-                    row.RemoveAt(remove_index);
+                for (int i = 0; i < Rows.Count; i++)
+                    Rows[i].RemoveAt(remove_index);
                 }
             }
         }

--- a/HTML5SDK/wwtlib/Layers/Table.cs
+++ b/HTML5SDK/wwtlib/Layers/Table.cs
@@ -326,12 +326,22 @@ namespace wwtlib
             return cloned_table;
         }
 
-        public void addColumn(string name, List<string> data)
+        public void AddColumn(string name, List<string> data)
         {
             Header.Add(name);
             for (int i = 0; i < data.Count; i++)
             {
                 Rows[i].Add(data[i]);
+            }
+        }
+
+        public void RemoveColumn(string name) {
+            int remove_index = Header.IndexOf(name);
+            if (remove_index > -1) {
+                Header.removeAt(remove_index);
+                for (string[] row in Rows) {
+                    row.removeAt(remove_index);
+                }
             }
         }
     }

--- a/HTML5SDK/wwtlib/Layers/Table.cs
+++ b/HTML5SDK/wwtlib/Layers/Table.cs
@@ -339,7 +339,7 @@ namespace wwtlib
             int remove_index = Header.IndexOf(name);
             if (remove_index > -1) {
                 Header.removeAt(remove_index);
-                for (string[] row in Rows) {
+                foreach (string[] row in Rows) {
                     row.removeAt(remove_index);
                 }
             }

--- a/HTML5SDK/wwtlib/Layers/Table.cs
+++ b/HTML5SDK/wwtlib/Layers/Table.cs
@@ -317,7 +317,7 @@ namespace wwtlib
             }
             for (int j = 0; j < Rows.Count; j++)
             {
-                cloned_table.Rows.Add([]);
+                cloned_table.Rows.Add(new List<string>());
                 for (int i = 0; i < Rows[j].Count; i++)
                 {
                     cloned_table.Rows[j].Add(Rows[j][i]);

--- a/HTML5SDK/wwtlib/Layers/Table.cs
+++ b/HTML5SDK/wwtlib/Layers/Table.cs
@@ -338,9 +338,9 @@ namespace wwtlib
         public void RemoveColumn(string name) {
             int remove_index = Header.IndexOf(name);
             if (remove_index > -1) {
-                Header.removeAt(remove_index);
+                Header.RemoveAt(remove_index);
                 foreach (string[] row in Rows) {
-                    row.removeAt(remove_index);
+                    row.RemoveAt(remove_index);
                 }
             }
         }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,20 +34,6 @@ jobs:
       targets: sdk
       workingDirectory: 'webclient'
 
-  - script: npm install mocha chai mocha-headless-chrome --save-dev
-    workingDirectory: tests
-    displayName: Installing mocha testing framework
-
-  - script: node_modules/.bin/mocha-headless-chrome -f tests.html -r xunit > test_results.xml
-    workingDirectory: tests
-    displayName: Running tests against JS SDK
-
-  # NOTE: The file produced above is actually in JUnit format, not xUnit!
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: 'JUnit'
-      testResultsFiles: 'tests/test_results.xml'
-
   - task: CopyFiles@2
     displayName: Copying SDK file to staging directory
     inputs:
@@ -61,3 +47,19 @@ jobs:
     inputs:
       artifactName: wwtsdk.js
       targetPath: $(Build.ArtifactStagingDirectory)
+
+  - script: npm install mocha chai mocha-headless-chrome --save-dev
+    workingDirectory: tests
+    displayName: Installing mocha testing framework
+
+  - script: node_modules/.bin/mocha-headless-chrome -f tests.html -r xunit > test_results.xml
+    workingDirectory: tests
+    displayName: Running tests against JS SDK
+
+  # NOTE: The file produced above is actually in JUnit format, not xUnit!
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: 'tests/test_results.xml'
+

--- a/tests/test_spreadsheetlayer.js
+++ b/tests/test_spreadsheetlayer.js
@@ -6,7 +6,7 @@ describe('SpreadSheetLayer', function() {
   it('should export XML with backward-compatibility for size normalization', function(done) {
 
     // Set up a SpreadSheetLayer and make use of the size normalization functionality
-    var csv = 'a,b,c\r\n266,-29,1\r\n267,-29,3\r\n267,-30,5\r\n266,-30,10\r\n';    
+    var csv = 'a,b,c\r\n266,-29,1\r\n267,-29,3\r\n267,-30,5\r\n266,-30,10\r\n';
     var layer = new wwtlib.SpreadSheetLayer()
     layer.updateData(csv, true, true, true)
     layer.set_sizeColumn(1);
@@ -15,17 +15,17 @@ describe('SpreadSheetLayer', function() {
     layer.set_normalizeSizeMax(-27);
     layer.set_normalizeSizeClip(false);
 
-    // Make sure we add the table to a file cabinet, as this triggers the addition
-    // of the normalized size column
-    var fc = new wwtlib.FileCabinet();
-    layer.addFilesToCabinet(fc);
-    assert.equal(fc.fileList.length, 1);
-
     // Export to XML
     var xmlWriter = new wwtlib.XmlTextWriter();
     layer.saveToXml(xmlWriter);
     xmlWriter._pending = true;
     xmlWriter._writePending(true);
+
+    // We call addFilesToCabinet after getting the XML of the layer since this
+    // is the order in which things happen when saving a tour.
+    var fc = new wwtlib.FileCabinet();
+    layer.addFilesToCabinet(fc);
+    assert.equal(fc.fileList.length, 1);
 
     // Now use a standard XML parser to load and check for attributes
     parser = new DOMParser();
@@ -35,7 +35,7 @@ describe('SpreadSheetLayer', function() {
     // sizeColumn should be set to a new fourth column (index=3 as 0-based)
     // while NormalizeSizeColumn is set to the actual column to scale
     assert.equal(layer_xml.getAttribute('SizeColumn'), 3);
-    assert.equal(layer_xml.getAttribute('NormalizeColumn'), 1);
+    assert.equal(layer_xml.getAttribute('NormalizeSizeColumn'), 1);
 
     // Check that the normalization attributes are set correctly
     assert.equal(JSON.parse(layer_xml.getAttribute('NormalizeSize')), true);

--- a/tests/test_spreadsheetlayer.js
+++ b/tests/test_spreadsheetlayer.js
@@ -1,0 +1,47 @@
+var assert = chai.assert;
+
+
+describe('SpreadSheetLayer', function() {
+
+  it('should export XML with backward-compatibility for size normalization', function() {
+
+    // Set up a SpreadSheetLayer and make use of the size normalization functionality
+    var csv = 'a,b,c\r\n266,-29,1\r\n267,-29,3\r\n267,-30,5\r\n266,-30,10\r\n';    
+    var layer = new wwtlib.SpreadSheetLayer()
+    layer.updateData(csv, true, true, true)
+    layer.set_sizeColumn(1);
+    layer.set_normalizeSize(true);
+    layer.set_normalizeSizeMin(2);
+    layer.set_normalizeSizeMax(10);
+    layer.set_normalizeSizeClip(false);
+
+    // Make sure we add the table to a file cabinet, as this triggers the addition
+    // of the normalized size column
+    var fc = new wwtlib.FileCabinet()
+    layer.addFilesToCabinet(fc)
+
+    // Export to XML
+    var xmlWriter = new wwtlib.XmlTextWriter();
+    layer.saveToXml(xmlWriter);
+    xmlWriter._pending = true;
+    xmlWriter._writePending(true);
+
+    // Now use a standard XML parser to load and check for attributes
+    parser = new DOMParser();
+    xmlDoc = parser.parseFromString(xmlWriter.body, "text/xml");
+    layer_xml = xmlDoc.getElementsByTagName('Layer')[0]
+
+    // sizeColumn should be set to a new fourth column (index=3 as 0-based)
+    // while NormalizeSizeColumn is set to the actual column to scale
+    assert.equal(layer_xml.getAttribute('SizeColumn'), 3);
+    assert.equal(layer_xml.getAttribute('NormalizeColumn'), 1);
+
+    // Check that the normalization attributes are set correctly
+    assert.equal(JSON.parse(layer_xml.getAttribute('NormalizeSize')), true);
+    assert.equal(JSON.parse(layer_xml.getAttribute('NormalizeSizeMin')), 2.);
+    assert.equal(JSON.parse(layer_xml.getAttribute('NormalizeSizeMax')), 10.);
+    assert.equal(JSON.parse(layer_xml.getAttribute('NormalizeSizeClip')), false);
+
+  });
+
+});

--- a/tests/test_spreadsheetlayer.js
+++ b/tests/test_spreadsheetlayer.js
@@ -42,6 +42,14 @@ describe('SpreadSheetLayer', function() {
     assert.equal(JSON.parse(layer_xml.getAttribute('NormalizeSizeMax')), 10.);
     assert.equal(JSON.parse(layer_xml.getAttribute('NormalizeSizeClip')), false);
 
+    // Now check that when loading back we get the same as the initial values
+    var new_layer = new wwtlib.Layer.fromXml(layer_xml);
+    assert.equal(new_layer.sizeColumn, 1);
+    assert.equal(new_layer.normalizeSize, true);
+    assert.equal(new_layer.normalizeSizeMin, 2.);
+    assert.equal(new_layer.normalizeSizeMax, 10.);
+    assert.equal(new_layer.normalizeSizeClip, false);
+
   });
 
 });

--- a/tests/test_spreadsheetlayer.js
+++ b/tests/test_spreadsheetlayer.js
@@ -17,8 +17,9 @@ describe('SpreadSheetLayer', function() {
 
     // Make sure we add the table to a file cabinet, as this triggers the addition
     // of the normalized size column
-    var fc = new wwtlib.FileCabinet()
-    layer.addFilesToCabinet(fc)
+    var fc = new wwtlib.FileCabinet();
+    layer.addFilesToCabinet(fc);
+    assert.equal(fc.fileList.length, 1);
 
     // Export to XML
     var xmlWriter = new wwtlib.XmlTextWriter();

--- a/tests/test_table.js
+++ b/tests/test_table.js
@@ -43,7 +43,7 @@ describe('Table', function() {
     table.header = ['d', 'e', 'f'];
     table.rows = [[4, 6, 'l'], [2, 2, 'k']];
     table.removeColumn('e');
-    assert.equal(table.save(), 'd\tf\tp\r\n4\tl\r\n2\tk\r\n');
+    assert.equal(table.save(), 'd\tf\r\n4\tl\r\n2\tk\r\n');
   });
 
 });

--- a/tests/test_table.js
+++ b/tests/test_table.js
@@ -38,5 +38,12 @@ describe('Table', function() {
     assert.equal(table.save(), 'd\te\tf\tp\r\n4\t6\tl\t4.5\r\n2\t2\tk\t9\r\n');
   });
 
+  it('should remove a column when calling removeColumn', function() {
+    var table = new wwtlib.Table();
+    table.header = ['d', 'e', 'f'];
+    table.rows = [[4, 6, 'l'], [2, 2, 'k']];
+    table.removeColumn('e');
+    assert.equal(table.save(), 'd\tf\tp\r\n4\tl\r\n2\tk\r\n');
+  });
 
 });

--- a/tests/test_table.js
+++ b/tests/test_table.js
@@ -1,0 +1,54 @@
+var assert = chai.assert;
+
+var CSV_TABLE = 'a,b,c\r\n1,2,3.5\r\n4,5,6.5\r\n'
+
+describe('Table', function() {
+
+    it('should load data from CSV strings', function() {
+    var table = new wwtlib.Table();
+    table.loadFromString(CSV_TABLE, false, true, true);
+    assert.deepEqual(table.header, ['a', 'b', 'c']);
+    assert.equal(table.rows.length, 2)
+    assert.deepEqual(table.rows[0], ['1', '2', '3.5']);
+    assert.deepEqual(table.rows[1], ['4', '5', '6.5']);
+  });
+
+  it('should append data from CSV strings when purge is not set', function() {
+    var table = new wwtlib.Table();
+    table.loadFromString(CSV_TABLE, false, true, true);
+    table.loadFromString(CSV_TABLE, false, false, true);
+    assert.deepEqual(table.header, ['a', 'b', 'c']);
+    assert.equal(table.rows.length, 4)
+    assert.deepEqual(table.rows[0], ['1', '2', '3.5']);
+    assert.deepEqual(table.rows[1], ['4', '5', '6.5']);
+    assert.deepEqual(table.rows[2], ['1', '2', '3.5']);
+    assert.deepEqual(table.rows[3], ['4', '5', '6.5']);
+  });
+
+  it('should save an existing table correctly', function() {
+    var table = new wwtlib.Table();
+    table.header = ['d', 'e', 'f'];
+    table.rows = [[4, 6, 'l'], [2, 2, 'k']];
+    assert.equal(table.save(), 'd\te\tf\r\n4\t6\tl\r\n2\t2\tk\r\n');
+  });
+
+  it('should copy cleanly when using copy()', function() {
+    var table1 = new wwtlib.Table();
+    table1.header = ['d', 'e', 'f'];
+    table1.rows = [[4, 6, 'l'], [2, 2, 'k']];
+    var table2 = table1.copy()
+    table2.rows[0][1] = 9
+    assert.equal(table1.save(), 'd\te\tf\r\n4\t6\tl\r\n2\t2\tk\r\n');
+    assert.equal(table2.save(), 'd\te\tf\r\n4\t9\tl\r\n2\t2\tk\r\n');
+  });
+
+  it('should include a new column when calling addColumn', function() {
+    var table = new wwtlib.Table();
+    table.header = ['d', 'e', 'f'];
+    table.rows = [[4, 6, 'l'], [2, 2, 'k']];
+    table.addColumn('p', [4.5, 9])
+    assert.equal(table.save(), 'd\te\tf\tp\r\n4\t6\tl\t4.5\r\n2\t2\tk\t9\r\n');
+  });
+
+
+});

--- a/tests/test_table.js
+++ b/tests/test_table.js
@@ -13,18 +13,6 @@ describe('Table', function() {
     assert.deepEqual(table.rows[1], ['4', '5', '6.5']);
   });
 
-  it('should append data from CSV strings when purge is not set', function() {
-    var table = new wwtlib.Table();
-    table.loadFromString(CSV_TABLE, false, true, true);
-    table.loadFromString(CSV_TABLE, false, false, true);
-    assert.deepEqual(table.header, ['a', 'b', 'c']);
-    assert.equal(table.rows.length, 4)
-    assert.deepEqual(table.rows[0], ['1', '2', '3.5']);
-    assert.deepEqual(table.rows[1], ['4', '5', '6.5']);
-    assert.deepEqual(table.rows[2], ['1', '2', '3.5']);
-    assert.deepEqual(table.rows[3], ['4', '5', '6.5']);
-  });
-
   it('should save an existing table correctly', function() {
     var table = new wwtlib.Table();
     table.header = ['d', 'e', 'f'];
@@ -36,7 +24,7 @@ describe('Table', function() {
     var table1 = new wwtlib.Table();
     table1.header = ['d', 'e', 'f'];
     table1.rows = [[4, 6, 'l'], [2, 2, 'k']];
-    var table2 = table1.copy()
+    var table2 = table1.Clone()
     table2.rows[0][1] = 9
     assert.equal(table1.save(), 'd\te\tf\r\n4\t6\tl\r\n2\t2\tk\r\n');
     assert.equal(table2.save(), 'd\te\tf\r\n4\t9\tl\r\n2\t2\tk\r\n');

--- a/tests/test_table.js
+++ b/tests/test_table.js
@@ -24,7 +24,7 @@ describe('Table', function() {
     var table1 = new wwtlib.Table();
     table1.header = ['d', 'e', 'f'];
     table1.rows = [[4, 6, 'l'], [2, 2, 'k']];
-    var table2 = table1.Clone()
+    var table2 = table1.clone()
     table2.rows[0][1] = 9
     assert.equal(table1.save(), 'd\te\tf\r\n4\t6\tl\r\n2\t2\tk\r\n');
     assert.equal(table2.save(), 'd\te\tf\r\n4\t9\tl\r\n2\t2\tk\r\n');

--- a/tests/test_table.js
+++ b/tests/test_table.js
@@ -1,12 +1,10 @@
 var assert = chai.assert;
 
-var CSV_TABLE = 'a,b,c\r\n1,2,3.5\r\n4,5,6.5\r\n'
-
 describe('Table', function() {
 
-    it('should load data from CSV strings', function() {
+  it('should load data from CSV strings', function() {
     var table = new wwtlib.Table();
-    table.loadFromString(CSV_TABLE, false, true, true);
+    table.loadFromString('a,b,c\r\n1,2,3.5\r\n4,5,6.5\r\n', false, true, true);
     assert.deepEqual(table.header, ['a', 'b', 'c']);
     assert.equal(table.rows.length, 2)
     assert.deepEqual(table.rows[0], ['1', '2', '3.5']);

--- a/tests/test_table.js
+++ b/tests/test_table.js
@@ -20,7 +20,7 @@ describe('Table', function() {
     assert.equal(table.save(), 'd\te\tf\r\n4\t6\tl\r\n2\t2\tk\r\n');
   });
 
-  it('should copy cleanly when using copy()', function() {
+  it('should copy cleanly when using clone()', function() {
     var table1 = new wwtlib.Table();
     table1.header = ['d', 'e', 'f'];
     table1.rows = [[4, 6, 'l'], [2, 2, 'k']];

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -14,6 +14,7 @@
     <script src="https://code.jquery.com/jquery-1.8.3.min.js"></script>
 
     <script src="test_color.js"></script>
+    <script src="test_table.js"></script>
 
     <script>
       mocha.run();

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -15,6 +15,7 @@
 
     <script src="test_color.js"></script>
     <script src="test_table.js"></script>
+    <script src="test_spreadsheetlayer.js"></script>
 
     <script>
       mocha.run();


### PR DESCRIPTION
This PR adds a few attributes that can be used to control whether the point sizes are interpreted as-is from the ``sizeColumn`` or whether they are normalized beforehand using:

```
new_size = (size - size_min) / (size_max - size_min)
```

In many cases, astronomers don't have tables with point sizes already in the table - instead they will have some value, e.g. mass or temperature and will want to map these to actual point sizes. Rather than have to re-generate the table many times, the attributes here allow normalization to be turned on in the SDK, and to control the min/max.

This will allow us to then implement a much more efficient approach for https://github.com/WorldWideTelescope/pywwt/issues/137 in PyWWT - at the moment, we constantly re-generate data tables and send them from Python to JS - with this, we'll be able to just modify the min/max.

Example usage in the JS SDK:

```js
csv = 'a,b,c\r\n266,-29,1\r\n267,-29,3\r\n267,-30,5\r\n266,-30,10\r\n';
layer = wwtlib.LayerManager.createSpreadsheetLayer('Sky', 'My Layer', csv);
layer.set_lngColumn(0);
layer.set_raUnits(1);
layer.set_latColumn(1);
layer.set_sizeColumn(2);
layer.set_scaleFactor(10);
layer.set_pointScaleType(0);
layer.set_normalizeSize(true);
layer.set_normalizeSizeMin(2);
layer.set_normalizeSizeMax(10);
layer.set_normalizeSizeClip(true);
wwt.gotoRaDecZoom(266.5, -29.5, 10, true);
```

The default is to not do any normalization, consistent with the current default behavior. In addition, this doesn't interact in any way with the XML files, which on the plus side means no breakage of tour file compatibility, and on the minus side means that these settings wouldn't be saved in a tour. If we are ok with adding new attributes to tour files, then I can do this.

Note that technically speaking, since the min/max default to 0 and 1, and clip defaults to ``false``, the ``normalizeSize`` option isn't really needed, but having it set to ``false`` does avoid even doing the normalization calculation at all, which might be better for performance (but it probably won't make much difference).

Also I've only implemented this for ``pointScaleType`` set to ``Linear`` or ``Power`` since those cases are straightfoward. ``Log`` normalization is a little trickier since it involves an additional constant (see the equation in [LogStretch](http://docs.astropy.org/en/stable/api/astropy.visualization.LogStretch.html#astropy.visualization.LogStretch) for astropy). And I think ``StellarMagnitude`` shouldn't be scaled/normalized since it has absolute meaning.