### PR TITLE
Split SetImageScale into two versions to address BSCALE/BZERO

### DIFF
--- a/HTML5SDK/wwtlib/Layers/FitsImage.cs
+++ b/HTML5SDK/wwtlib/Layers/FitsImage.cs
@@ -88,6 +88,7 @@ namespace wwtlib
         public int Height = 0;
         public int NumAxis = 0;
         public double BZero = 0;
+        public double BScale = 1;
         public int[] AxisSize;
         public object DataBuffer;
         public DataTypes DataType = DataTypes.None;
@@ -199,6 +200,11 @@ namespace wwtlib
             if (header.ContainsKey("BZERO"))
             {
                 BZero = Double.Parse(header["BZERO"]);
+            }
+
+            if (header.ContainsKey("BSCALE"))
+            {
+                BScale = Double.Parse(header["BSCALE"]);
             }
 
             AxisSize = new int[NumAxis];

--- a/HTML5SDK/wwtlib/Layers/ImageSetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/ImageSetLayer.cs
@@ -168,6 +168,12 @@ namespace wwtlib
 
         public void SetImageScale(ScaleTypes scaleType, double min, double max)
         {
+            Script.Literal("console.warn('SetImageScale is considered deprecated. Use setImageScaleRaw or setImageScalePhysical instead.')");
+            SetImageScaleRaw(scaleType, min, max);
+        }
+
+        public void SetImageScaleRaw(ScaleTypes scaleType, double min, double max)
+        {
             this.min = min;
             this.max = max;
             this.lastScale = scaleType;
@@ -176,6 +182,19 @@ namespace wwtlib
             {
                 Histogram.UpdateScale(this, scaleType, min, max);
             }
+        }
+
+        public void SetImageScalePhysical(ScaleTypes scaleType, double min, double max)
+        {
+            double newMin = min;
+            double newMax = max;
+            if (imageSet.WcsImage is FitsImage)
+            {
+                FitsImage img = imageSet.WcsImage as FitsImage;
+                newMin = (newMin - img.BZero) / img.BScale;
+                newMax = (newMax - img.BZero) / img.BScale;
+            }
+            SetImageScaleRaw(scaleType, newMin, newMax);
         }
 
         public void SetImageZ(double z)


### PR DESCRIPTION
This is one way to address #210 (FitsImage does not properly support BSCALE/BZERO) based on the discussion thread. The idea is to have two versions of SetImageScale function, one that accounts for the BSCALE/BZERO in the FITS file, and one that uses the raw values in the file.