### PR TITLE
Fix bug in SpreadSheetLayer loading

### DIFF
--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -182,11 +182,14 @@ namespace wwtlib
 
         public override void LoadData(TourDocument tourDoc, string filename)
         {
-            table = new Table();
-            Blob blob = tourDoc.GetFileBlob(filename);
-            this.GetStringFromGzipBlob(blob, delegate (string data)
+            System.Html.Data.Files.Blob blob = tourDoc.GetFileBlob(filename);
+
+            FileReader doc = new FileReader();
+            doc.OnLoadEnd = delegate (FileProgressEvent ee)
             {
-                table.LoadFromString(data, false, true, true);
+                string data = doc.Result as string;
+                LoadFromString(data, false, false, true, true);
+
                 ComputeDateDomainRange(-1, -1);
 
                 if (DynamicData && AutoUpdate)
@@ -195,9 +198,9 @@ namespace wwtlib
                 }
                 dataDirty = true;
                 dirty = true;
-            });
+            };
+            doc.ReadAsText(blob);
         }
-
 
         string fileName;
 


### PR DESCRIPTION
``SpreadSheetLayer.loadData`` incorrectly assumed that the layer data was gzip-compressed. In fact, when saving tours from the web client or the desktop client, the layer data is not gzip-compressed.

Here's an example tour file with a SpreadSheetLayer.

https://www.dropbox.com/s/xl9p9cu6ivizbmw/tourwithdata.wtt?dl=1

This works fine on the Desktop client and also works fine with the web client with the present PR. With the 'live' web client, I see the following error in the console:

```
Uncaught incorrect header check       pako_inflate.min.js:2 
```