### PR TITLE
Added minimal (JS) test suite

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,13 @@ jobs:
       targets: sdk
       workingDirectory: 'webclient'
 
+  - script: npm install -g mocha chai mocha-headless-chrome
+    displayName: Installing mocha testing framework
+
+  - script: mocha-headless-chrome -f tests.html
+    workingDirectory: tests
+    displayName: Running tests against JS SDK
+
   - task: CopyFiles@2
     displayName: Copying SDK file to staging directory
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,18 +34,19 @@ jobs:
       targets: sdk
       workingDirectory: 'webclient'
 
-  - script: npm install mocha chai mocha-headless-chrome mocha-junit-reporter --save-dev
+  - script: npm install mocha chai mocha-headless-chrome --save-dev
     workingDirectory: tests
     displayName: Installing mocha testing framework
 
-  - script: node_modules\.bin\mocha-headless-chrome -f tests.html -r mocha-junit-reporter
+  - script: node_modules/.bin/mocha-headless-chrome -f tests.html -r xunit > test_results.xml
     workingDirectory: tests
     displayName: Running tests against JS SDK
 
+  # NOTE: The file produced above is actually in JUnit format, not xUnit!
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'JUnit'
-      testResultsFiles: 'test-results.xml'
+      testResultsFiles: 'tests/test_results.xml'
 
   - task: CopyFiles@2
     displayName: Copying SDK file to staging directory

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,9 @@ jobs:
       targets: sdk
       workingDirectory: 'webclient'
 
-  - script: npm install -g mocha chai mocha-headless-chrome
+  - script: ¦
+      npm install mocha chai --save-dev
+      npm install -g mocha-headless-chrome
     displayName: Installing mocha testing framework
 
   - script: mocha-headless-chrome -f tests.html

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
       targets: sdk
       workingDirectory: 'webclient'
 
-  - script: ¦
+  - script: |
       npm install mocha chai --save-dev
       npm install -g mocha-headless-chrome
     displayName: Installing mocha testing framework

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ jobs:
       workingDirectory: 'webclient'
 
   - script: npm install mocha chai mocha-headless-chrome mocha-junit-reporter --save-dev
+    workingDirectory: tests
     displayName: Installing mocha testing framework
 
   - script: node_modules\.bin\mocha-headless-chrome -f tests.html -r mocha-junit-reporter

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,14 +34,17 @@ jobs:
       targets: sdk
       workingDirectory: 'webclient'
 
-  - script: |
-      npm install mocha chai --save-dev
-      npm install -g mocha-headless-chrome
+  - script: npm install mocha chai mocha-headless-chrome mocha-junit-reporter --save-dev
     displayName: Installing mocha testing framework
 
-  - script: mocha-headless-chrome -f tests.html
+  - script: node_modules\.bin\mocha-headless-chrome -f tests.html -r mocha-junit-reporter
     workingDirectory: tests
     displayName: Running tests against JS SDK
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: 'test-results.xml'
 
   - task: CopyFiles@2
     displayName: Copying SDK file to staging directory

--- a/tests/test_color.js
+++ b/tests/test_color.js
@@ -1,0 +1,11 @@
+var assert = chai.assert;
+
+describe('Color', function() {
+  it('should parse strings', function() {
+    var color = wwtlib.Color.fromName("red");
+    assert.equal(color.a, 255);
+    assert.equal(color.r, 255);
+    assert.equal(color.g, 0);
+    assert.equal(color.b, 0);
+  });
+});

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Mocha Tests</title>
+    <link rel="stylesheet" href="node_modules/mocha/mocha.css">
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="node_modules/mocha/mocha.js"></script>
+    <script src="node_modules/chai/chai.js"></script>
+    <script>mocha.setup('bdd')</script>
+
+    <script src="../webclient/sdk/wwtsdk.js"></script>
+    <script src="https://code.jquery.com/jquery-1.8.3.min.js"></script>
+
+    <script src="test_color.js"></script>
+
+    <script>
+      mocha.run();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
I realized that https://github.com/WorldWideTelescope/wwt-web-client/pull/249 is not really what we want - since the final product made here is the JS code, I think it makes more sense to run the tests against the final JS code rather than the C# code.

This PR makes use of the mocha testing framework which allows us to run the tests via an HTML file, either interactively or via a headless command (which I've added to the Azure Pipelines configuration).