### PR TITLE
Make web client able to read uncompressed data layers

### DIFF
--- a/tests/test_layer.js
+++ b/tests/test_layer.js
@@ -1,0 +1,41 @@
+var assert = chai.assert;
+
+
+describe('Layer', function() {
+
+  it('Layer.getStringFromGzipBlob should keep non-compressed strings as-is', function(done) {
+
+    var csv = 'a,b,c\r\n266,-29,1\r\n267,-29,3\r\n267,-30,5\r\n266,-30,10\r\n';
+    var blob = new Blob([csv])
+
+    var layer = new wwtlib.SpreadSheetLayer()
+    layer.getStringFromGzipBlob(blob, function(data) {
+        assert.equal(data, csv);
+        done()
+    });
+
+  });
+
+  it('Layer.getStringFromGzipBlob should decompress compressed strings', function(done) {
+
+    var csv = 'a,b,c\r\n266,-29,1\r\n267,-29,3\r\n267,-30,5\r\n266,-30,10\r\n';
+
+    // The above string was compressed and converted to base64 - we then decode the base64
+    // string into a byte array that we construct a blob with
+    var byteCharacters = atob('eJxL1EnSSeblMjIz09E1stQxBDHNwUxjKNPYQMcUqgDINDTg5QIAAcIJFg==');
+    const byteNumbers = new Array(byteCharacters.length);
+    for (let i = 0; i < byteCharacters.length; i++) {
+        byteNumbers[i] = byteCharacters.charCodeAt(i);
+    }
+    const byteArray = new Uint8Array(byteNumbers);
+    var blob = new Blob([byteArray], {type: 'application/gzip'})
+
+    var layer = new wwtlib.SpreadSheetLayer()
+    layer.getStringFromGzipBlob(blob, function(data) {
+        assert.equal(data, csv);
+        done()
+    });
+
+  });
+
+});

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -3,6 +3,7 @@
   <head>
     <title>Mocha Tests</title>
     <link rel="stylesheet" href="node_modules/mocha/mocha.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pako/1.0.3/pako_inflate.js"></script>
   </head>
   <body>
     <div id="mocha"></div>
@@ -15,6 +16,7 @@
 
     <script src="test_color.js"></script>
     <script src="test_table.js"></script>
+    <script src="test_layer.js"></script>
     <script src="test_spreadsheetlayer.js"></script>
 
     <script>


### PR DESCRIPTION
The web client currently writes out uncompressed data layers but expects them to be compressed when reading them in. This PR adjusts the getStringFromGzipBlob function to return strings as-is if they fail the zlib/gzip header test.

For now this just adds a regression test, and a fix will follow.