### PR TITLE
HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs: don't draw points with invalid colors

### DIFF
--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -821,6 +821,9 @@ namespace wwtlib
                                 break;
                         }
 
+                        if (pointColor == null) {
+                            pointColor = Colors.Transparent;
+                        }
 
                         if (sizeColumn > -1)
                         {


### PR DESCRIPTION
A corner case missed in the initial pywwt work: things didn't work here if we tried to colormap a NaN value.

Due to how PointList interacts with the blanket exception handling in this function, a null color leads to invalid internal state that causes problems in _initBuffer.