### PR TITLE
HTML5SDK/wwtlib/Layers/ColorMapContainer.cs: do the sensible thing with FromNameColormap(null)

### DIFF
--- a/HTML5SDK/wwtlib/Layers/ColorMapContainer.cs
+++ b/HTML5SDK/wwtlib/Layers/ColorMapContainer.cs
@@ -60,6 +60,10 @@ namespace wwtlib
 
         public static ColorMapContainer FromNamedColormap(string name)
         {
+            if (name == null) {
+                return null;
+            }
+
             // Names are chosen to match matplotlib (which explains why some
             // are less-than-ideal).
             switch (name.ToLowerCase())


### PR DESCRIPTION
Some corner cases were leading to null derefs here.