### PR TITLE
Provide helper class to help set CDN server

### DIFF
--- a/HTML5SDK/wwtlib/Constellations.cs
+++ b/HTML5SDK/wwtlib/Constellations.cs
@@ -388,7 +388,7 @@ namespace wwtlib
         }
 
 
-        public static Constellations Containment = Constellations.Create("Constellations", "//worldwidetelescope.org/data/constellations.txt", true, true, true);
+        public static Constellations Containment = Constellations.Create("Constellations", URLHelpers.FromWWW("data/constellations.txt"), true, true, true);
         //public static Constellations Containment = Constellations.Create("Constellations", "//localhost/data/constellations.txt", true, true, true);
 
         static string constToDraw = "";
@@ -496,8 +496,8 @@ namespace wwtlib
                 if (artFile == null)
                 {
                     artFile = new Folder();
-                    artFile.LoadFromUrl("//worldwidetelescope.org/wwtweb/catalog.aspx?W=hevelius", OnArtReady);
-                    //artFile.LoadFromUrl("//worldwidetelescope.org/wwtweb/catalog.aspx?W=and", OnArtReady);
+                    artFile.LoadFromUrl(URLHelpers.FromWWW("wwtweb/catalog.aspx?W=hevelius"), OnArtReady);
+                    //artFile.LoadFromUrl(URLHelpers.FromWWW("wwtweb/catalog.aspx?W=and"), OnArtReady);
                 }
 
                 return;
@@ -550,7 +550,7 @@ namespace wwtlib
         {
             //string url = "//worldwidetelescope.org/data/constellationNames_RADEC_EN.txt";
             //string url = "//localhost/data/constellationNames_RADEC_EN.txt";
-            string url = "//worldwidetelescope.org/wwtweb/catalog.aspx?q=ConstellationNamePositions_EN";
+            string url = URLHelpers.FromWWW("wwtweb/catalog.aspx?q=ConstellationNamePositions_EN");
             webFileConstNames = new WebFile(url);
             webFileConstNames.OnStateChange = LoadNames;
             webFileConstNames.Send();

--- a/HTML5SDK/wwtlib/Constellations.cs
+++ b/HTML5SDK/wwtlib/Constellations.cs
@@ -86,7 +86,7 @@ namespace wwtlib
 
 
 
-            Lineset lineSet = null; 
+            Lineset lineSet = null;
 
 
             try
@@ -176,8 +176,8 @@ namespace wwtlib
                         type = PointType.Line;
 
                     }
-                    
-                
+
+
             }
             catch
             {
@@ -448,7 +448,7 @@ namespace wwtlib
         {
             if (NamesBatch == null)
             {
-            
+
                 InitializeConstellationNames();
                 if (NamesBatch == null)
                 {
@@ -472,7 +472,7 @@ namespace wwtlib
             foreach (string key in ConstellationCentroids.Keys)
             {
                 IPlace centroid = ConstellationCentroids[key];
-            
+
                 Vector3d center = Coordinates.RADecTo3dAu(centroid.RA, centroid.Dec, 1);
                 Vector3d up = Vector3d.Create(0, 1, 0);
                 string name = centroid.Name;
@@ -576,7 +576,7 @@ namespace wwtlib
             Abbreviations = new Dictionary<string, string>();
             BitIDs = new Dictionary<string, int>();
             string[] rows = file.Split("\r\n");
-            int id = 0;        
+            int id = 0;
             string line;
             foreach (string row in rows)
             {

--- a/HTML5SDK/wwtlib/Folder.cs
+++ b/HTML5SDK/wwtlib/Folder.cs
@@ -132,7 +132,7 @@ namespace wwtlib
             {
                 thumbnailUrlField = node.Attributes.GetNamedItem("Thumbnail").Value;
             }
-           
+
             // load Children
 
             foreach (XmlNode child in node.ChildNodes)
@@ -160,7 +160,7 @@ namespace wwtlib
                         break;
                 }
             }
-     
+
 
         //bool Browseable { get; set; }
         //System.Collections.Generic.List<Folder> Folders { get; set; }
@@ -293,7 +293,7 @@ namespace wwtlib
             {
                 callback();
             }
-            
+
 
         }
         List<IThumbnail> childList = new List<IThumbnail>();
@@ -383,8 +383,8 @@ namespace wwtlib
         private List<Tour> tours = new List<Tour>();
         private List<Folder> folders = new List<Folder>();
         private List<Place> places = new List<Place>();
-      
-        
+
+
         private string nameField;
 
         private FolderGroup groupField;
@@ -411,7 +411,7 @@ namespace wwtlib
 
 
         /// <remarks/>
-        /// 
+        ///
 
         long communityIdField = 0;
 

--- a/HTML5SDK/wwtlib/Folder.cs
+++ b/HTML5SDK/wwtlib/Folder.cs
@@ -544,7 +544,7 @@ namespace wwtlib
                 if (string.IsNullOrEmpty(thumbnailUrlField))
                 {
 
-                    return "//worldwidetelescope.org/wwtweb/thumbnail.aspx?name=folder";
+                    return URLHelpers.FromWWW("wwtweb/thumbnail.aspx?name=folder");
                 }
 
                 return this.thumbnailUrlField;

--- a/HTML5SDK/wwtlib/FolderUp.cs
+++ b/HTML5SDK/wwtlib/FolderUp.cs
@@ -39,7 +39,7 @@ namespace wwtlib
         {
             get
             {
-                return "//worldwidetelescope.org/wwtweb/thumbnail.aspx?Name=folderup";
+                return URLHelpers.FromWWW("wwtweb/thumbnail.aspx?Name=folderup");
             }
             set
             {

--- a/HTML5SDK/wwtlib/Graphics/Primatives3d.cs
+++ b/HTML5SDK/wwtlib/Graphics/Primatives3d.cs
@@ -935,7 +935,7 @@ namespace wwtlib
                     {
                         if (starTexture == null)
                         {
-                            starTexture = Planets.LoadPlanetTexture("//cdn.worldwidetelescope.org/webclient/images/StarProfileAlpha.png");
+                            starTexture = Planets.LoadPlanetTexture(URL.FromCDN("webclient/images/StarProfileAlpha.png"));
                         }
 
                         int count = this.points.Count;

--- a/HTML5SDK/wwtlib/Graphics/Primatives3d.cs
+++ b/HTML5SDK/wwtlib/Graphics/Primatives3d.cs
@@ -935,7 +935,7 @@ namespace wwtlib
                     {
                         if (starTexture == null)
                         {
-                            starTexture = Planets.LoadPlanetTexture(URL.FromCDN("webclient/images/StarProfileAlpha.png"));
+                            starTexture = Planets.LoadPlanetTexture(URLHelpers.FromCDN("webclient/images/StarProfileAlpha.png"));
                         }
 
                         int count = this.points.Count;

--- a/HTML5SDK/wwtlib/Graphics/Primatives3d.cs
+++ b/HTML5SDK/wwtlib/Graphics/Primatives3d.cs
@@ -84,12 +84,12 @@ namespace wwtlib
             if (renderContext.gl == null)
             {
                 Vector3d viewPoint = Vector3d.TransformCoordinate(renderContext.ViewPoint, ViewTransform);
-                
+
 
 
                 CanvasContext2D ctx = renderContext.Device;
                 ctx.Save();
-                
+
                 ctx.StrokeStyle = color.ToString();
                 ctx.LineWidth = 2;
                 ctx.Alpha = .25;
@@ -107,9 +107,9 @@ namespace wwtlib
 
 
                         ctx.Stroke();
-                       
+
                     }
-                } 
+                }
                 ctx.Restore();
             }
             else
@@ -128,8 +128,8 @@ namespace wwtlib
                 }
             }
         }
-           
-    
+
+
 
         //List<SharpDX.Direct3D11.VertexBufferBinding> lineBufferBindings = new List<SharpDX.Direct3D11.VertexBufferBinding>();
 
@@ -213,7 +213,7 @@ namespace wwtlib
 
         void EmptyLineBuffer()
         {
-           
+
 
         }
 
@@ -747,7 +747,7 @@ namespace wwtlib
 
         }
 
-       
+
 
         public void Draw(RenderContext renderContext, float opacity, CullMode cull)
         {
@@ -756,7 +756,7 @@ namespace wwtlib
                 return;
             }
 
-            
+
 
             //renderContext.DepthStencilMode = DepthBuffered ? (WriteZbuffer ? DepthStencilMode.ZReadWrite : DepthStencilMode.ZReadOnly) : DepthStencilMode.Off;
 
@@ -1078,7 +1078,7 @@ namespace wwtlib
                     );
 
                 renderContext.gl.drawArrays(GL.POINTS, 0, pointBuffer.Count);
-            }     
+            }
         }
     }
 

--- a/HTML5SDK/wwtlib/Grids.cs
+++ b/HTML5SDK/wwtlib/Grids.cs
@@ -21,7 +21,7 @@ namespace wwtlib
         {
             if (milkyWayImage == null)
             {
-                milkyWayImage = Planets.LoadPlanetTexture(URL.FromCDN("webclient/images/milkywaybar.jpg"));
+                milkyWayImage = Planets.LoadPlanetTexture(URLHelpers.FromCDN("webclient/images/milkywaybar.jpg"));
             }
 
 
@@ -329,7 +329,7 @@ namespace wwtlib
                         }
 
 
-                        string name = URL.FromCDN(string.Format("webclient/images/gal_{0}.jpg", num));
+                        string name = URLHelpers.FromCDN(string.Format("webclient/images/gal_{0}.jpg", num));
 
                         galaxyTextures[i] = Planets.LoadPlanetTexture(name);
 

--- a/HTML5SDK/wwtlib/Grids.cs
+++ b/HTML5SDK/wwtlib/Grids.cs
@@ -35,7 +35,7 @@ namespace wwtlib
             double lngMin = -64;
             double lngMax = 64;
 
-            //// Create a vertex buffer 
+            //// Create a vertex buffer
             galaxyImageVertexBuffer = new PositionTextureVertexBuffer((subdivs + 1) * (subdivs + 1));
             PositionTexture[] verts = (PositionTexture[])galaxyImageVertexBuffer.Lock();
 

--- a/HTML5SDK/wwtlib/Grids.cs
+++ b/HTML5SDK/wwtlib/Grids.cs
@@ -21,7 +21,7 @@ namespace wwtlib
         {
             if (milkyWayImage == null)
             {
-                milkyWayImage = Planets.LoadPlanetTexture("//cdn.worldwidetelescope.org/webclient/images/milkywaybar.jpg");
+                milkyWayImage = Planets.LoadPlanetTexture(URL.FromCDN("webclient/images/milkywaybar.jpg"));
             }
 
 
@@ -329,7 +329,7 @@ namespace wwtlib
                         }
 
 
-                        string name = string.Format("//cdn.worldwidetelescope.org/webclient/images/gal_{0}.jpg", num);
+                        string name = URL.FromCDN(string.Format("webclient/images/gal_{0}.jpg", num));
 
                         galaxyTextures[i] = Planets.LoadPlanetTexture(name);
 

--- a/HTML5SDK/wwtlib/Grids.cs
+++ b/HTML5SDK/wwtlib/Grids.cs
@@ -183,7 +183,7 @@ namespace wwtlib
         {
             if (!starsDownloading)
             {
-                GetStarFile("//worldwidetelescope.org/wwtweb/catalog.aspx?Q=hipparcos");
+                GetStarFile(URLHelpers.FromWWW("wwtweb/catalog.aspx?Q=hipparcos"));
                 starsDownloading = true;
             }
 
@@ -448,7 +448,7 @@ namespace wwtlib
         {
             if (!downloadingGalaxy)
             {
-                GetGalaxyFile("//worldwidetelescope.org/wwtweb/catalog.aspx?Q=cosmosnewbin");
+                GetGalaxyFile(URLHelpers.FromWWW("wwtweb/catalog.aspx?Q=cosmosnewbin"));
                 downloadingGalaxy = true;
             }
             return false;

--- a/HTML5SDK/wwtlib/Imageset.cs
+++ b/HTML5SDK/wwtlib/Imageset.cs
@@ -69,7 +69,7 @@ namespace wwtlib
             get { return projection; }
             set { projection = value; }
         }
-    
+
         private string referenceFrame;
 
         public string ReferenceFrame
@@ -120,7 +120,7 @@ namespace wwtlib
 
         public int GetHashCode()
         {
-            
+
             return Util.GetHashCode(Url);
         }
 
@@ -286,8 +286,8 @@ namespace wwtlib
                              node.Attributes.GetNamedItem("").Value,
                             Convert.ToDouble(node.Attributes.GetNamedItem("").Value),
                             Convert.ToInt32(node.Attributes.GetNamedItem("").Value),
- 
- 
+
+
          * */
         string altUrl = "";
 
@@ -321,7 +321,7 @@ namespace wwtlib
                 BandPass bandPass = BandPass.Visible;
 
                 bandPass = (BandPass)Enums.Parse("BandPass",node.Attributes.GetNamedItem("BandPass").Value);
-                
+
                 int wf = 1;
                 if (node.Attributes.GetNamedItem("WidthFactor") != null)
                 {
@@ -331,7 +331,7 @@ namespace wwtlib
                 if (node.Attributes.GetNamedItem("Generic") == null || !bool.Parse(node.Attributes.GetNamedItem("Generic").Value.ToString()))
                 {
                     projection = (ProjectionType)Enums.Parse("ProjectionType", node.Attributes.GetNamedItem("Projection").Value);
-                    
+
                     string fileType = node.Attributes.GetNamedItem("FileType").Value.ToString();
                     if (!fileType.StartsWith("."))
                     {
@@ -609,8 +609,8 @@ namespace wwtlib
         //    if (left == null ^ right == null)
         //    {
         //        return false;
-        //    }      
-        //    return (left.Url.GetHashCode() == right.Url.GetHashCode());   
+        //    }
+        //    return (left.Url.GetHashCode() == right.Url.GetHashCode());
         //}
 
         //public static bool operator !=(ImageSet left, ImageSet right)
@@ -618,7 +618,7 @@ namespace wwtlib
         //    if (left == right )
         //    {
         //        return false;
-        //    }       
+        //    }
         //    if ( left == null ^ right == null)
         //    {
         //        return true;
@@ -651,7 +651,7 @@ namespace wwtlib
             Imageset b = (Imageset)obj;
 
             return (Util.GetHashCode(b.Url) == Util.GetHashCode(this.Url) && b.DataSetType == this.DataSetType && b.BandPass == this.BandPass && b.Generic == this.Generic);
-            
+
         }
 
         private Matrix3d matrix;
@@ -734,7 +734,7 @@ namespace wwtlib
             temp.rotation = 0;
             //todo add scale
             temp.thumbnailUrl = "";
-      
+
             temp.matrix = Matrix3d.Identity;
             temp.matrix.Multiply(Matrix3d.RotationX((((temp.Rotation)) / 180f * Math.PI)));
             temp.matrix.Multiply(Matrix3d.RotationZ(((temp.CenterY) / 180f * Math.PI)));

--- a/HTML5SDK/wwtlib/Imageset.cs
+++ b/HTML5SDK/wwtlib/Imageset.cs
@@ -436,7 +436,7 @@ namespace wwtlib
                     string url = "";
                     if (node.Attributes.GetNamedItem("Url") != null)
                     {
-                        url = URLhelpers.Patch(node.Attributes.GetNamedItem("Url").Value.ToString());
+                        url = URLHelpers.Patch(node.Attributes.GetNamedItem("Url").Value.ToString());
                     }
 
                     int baseTileLevel = 0;

--- a/HTML5SDK/wwtlib/Imageset.cs
+++ b/HTML5SDK/wwtlib/Imageset.cs
@@ -436,7 +436,7 @@ namespace wwtlib
                     string url = "";
                     if (node.Attributes.GetNamedItem("Url") != null)
                     {
-                        url = node.Attributes.GetNamedItem("Url").Value.ToString();
+                        url = URLhelpers.Patch(node.Attributes.GetNamedItem("Url").Value.ToString());
                     }
 
                     int baseTileLevel = 0;

--- a/HTML5SDK/wwtlib/Imageset.cs
+++ b/HTML5SDK/wwtlib/Imageset.cs
@@ -144,7 +144,7 @@ namespace wwtlib
             {
                 if (String.IsNullOrEmpty(demUrl) && projection == ProjectionType.Mercator)
                 {
-                    return "//worldwidetelescope.org/wwtweb/BingDemTile.aspx?Q={0},{1},{2}";      
+                    return URLHelpers.FromWWW("wwtweb/BingDemTile.aspx?Q={0},{1},{2}");
                    // return "//ecn.t{S}.tiles.virtualearth.net/tiles/d{Q}.elv?g=1&n=z";
                 }
                 return demUrl;

--- a/HTML5SDK/wwtlib/Layers/LayerManager.cs
+++ b/HTML5SDK/wwtlib/Layers/LayerManager.cs
@@ -173,7 +173,7 @@ namespace wwtlib
         //static List<Layer> layers = new List<Layer>();
         static LayerManager()
         {
-            GetMoonFile("//worldwidetelescope.org/wwtweb/catalog.aspx?Q=moons");
+            GetMoonFile(URLHelpers.FromWWW("wwtweb/catalog.aspx?Q=moons"));
             //InitLayers();
         }
         static string moonfile = "";
@@ -204,7 +204,7 @@ namespace wwtlib
                 string[] isstle = new string[0];
 
                 //This is downloaded now on startup
-                string url = "http://worldwidetelescope.org/wwtweb/isstle.aspx";
+                string url = URLHelpers.FromWWW("wwtweb/isstle.aspx");
 
                 WebFile webFile;
 

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -3003,7 +3003,7 @@ namespace wwtlib
     public class PushPin
     {
         static Dictionary<int, WebGLTexture> pinTextureCache = new Dictionary<int, WebGLTexture>();
-        static Texture Pins = Planets.LoadPlanetTexture("//cdn.worldwidetelescope.org/webclient/images/pins.png");
+        static Texture Pins = Planets.LoadPlanetTexture(URL.FromCDN("webclient/images/pins.png"));
         public static WebGLTexture GetPushPinTexture(int pinId)
         {
             WebGLTexture texture = null;

--- a/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
+++ b/HTML5SDK/wwtlib/Layers/SpreadSheetLayer.cs
@@ -3003,7 +3003,7 @@ namespace wwtlib
     public class PushPin
     {
         static Dictionary<int, WebGLTexture> pinTextureCache = new Dictionary<int, WebGLTexture>();
-        static Texture Pins = Planets.LoadPlanetTexture(URL.FromCDN("webclient/images/pins.png"));
+        static Texture Pins = Planets.LoadPlanetTexture(URLHelpers.FromCDN("webclient/images/pins.png"));
         public static WebGLTexture GetPushPinTexture(int pinId)
         {
             WebGLTexture texture = null;

--- a/HTML5SDK/wwtlib/MainView.cs
+++ b/HTML5SDK/wwtlib/MainView.cs
@@ -10,10 +10,10 @@ using System.Net;
 using System.Serialization;
 namespace wwtlib
 {
-    
+
     internal static class MainView
     {
-        
+
 
         static MainView()
         {
@@ -56,10 +56,10 @@ namespace wwtlib
 
         }
 
-       
 
 
 
-       
+
+
     }
 }

--- a/HTML5SDK/wwtlib/MainView.cs
+++ b/HTML5SDK/wwtlib/MainView.cs
@@ -37,7 +37,7 @@ namespace wwtlib
             //};
             //xhr.Send();
 
-            //Wtml.GetWtmlFile("//worldwidetelescope.org/wwtweb/catalog.aspx?W=ExploreRoot");
+            //Wtml.GetWtmlFile(URLHelpers.FromWWW("wwtweb/catalog.aspx?W=ExploreRoot"));
             //Wtml.GetWtmlFile("imagesets.xml");
 
         }

--- a/HTML5SDK/wwtlib/MinorPlanets.cs
+++ b/HTML5SDK/wwtlib/MinorPlanets.cs
@@ -85,7 +85,7 @@ namespace wwtlib
             {
                 if (starTexture == null)
                 {
-                    starTexture = Planets.LoadPlanetTexture("//cdn.worldwidetelescope.org/webclient/images/starProfileAlpha.png");
+                    starTexture = Planets.LoadPlanetTexture(URL.FromCDN("webclient/images/starProfileAlpha.png"));
                 }
                 for (int i = 0; i < 7; i++)
                 {
@@ -132,7 +132,7 @@ namespace wwtlib
     
         private static void StartInit()
         {
-            GetMpcFile("//cdn.worldwidetelescope.org/wwtweb/catalog.aspx?Q=mpcbin");
+            GetMpcFile(URL.FromCDN("wwtweb/catalog.aspx?Q=mpcbin"));
         }
 
         public static void InitMPCVertexBuffer()

--- a/HTML5SDK/wwtlib/MinorPlanets.cs
+++ b/HTML5SDK/wwtlib/MinorPlanets.cs
@@ -85,7 +85,7 @@ namespace wwtlib
             {
                 if (starTexture == null)
                 {
-                    starTexture = Planets.LoadPlanetTexture(URL.FromCDN("webclient/images/starProfileAlpha.png"));
+                    starTexture = Planets.LoadPlanetTexture(URLHelpers.FromCDN("webclient/images/starProfileAlpha.png"));
                 }
                 for (int i = 0; i < 7; i++)
                 {
@@ -132,7 +132,7 @@ namespace wwtlib
 
         private static void StartInit()
         {
-            GetMpcFile(URL.FromCDN("wwtweb/catalog.aspx?Q=mpcbin"));
+            GetMpcFile(URLHelpers.FromCDN("wwtweb/catalog.aspx?Q=mpcbin"));
         }
 
         public static void InitMPCVertexBuffer()

--- a/HTML5SDK/wwtlib/MinorPlanets.cs
+++ b/HTML5SDK/wwtlib/MinorPlanets.cs
@@ -11,7 +11,7 @@ namespace wwtlib
     class MinorPlanets
     {
         public static List<EOE> MPCList = new List<EOE>();
-      
+
         static WebFile webMpcFile;
 
         public static void GetMpcFile(string url)
@@ -65,7 +65,7 @@ namespace wwtlib
         static BlendState[] mpcBlendStates = new BlendState[7];
 
         public static Texture starTexture = null;
-        // ** Begin 
+        // ** Begin
         public static void DrawMPC3D(RenderContext renderContext, float opacity, Vector3d centerPoint)
         {
             double zoom = renderContext.ViewCamera.Zoom;
@@ -73,7 +73,7 @@ namespace wwtlib
 
             int alpha = Math.Min(255, Math.Max(0, (int)distAlpha));
 
-        
+
 
             if (alpha > 254)
             {
@@ -121,15 +121,15 @@ namespace wwtlib
                         KeplerPointSpriteShader.Use(renderContext, matrixWV, mpcVertexBuffer[i].VertexBuffer, starTexture.Texture2d, Colors.White,
                             opacity * mpcBlendStates[i].Opacity, false,
                             (float)(SpaceTimeController.JNow - KeplerVertex.baseDate), 0, renderContext.CameraPosition, 200f, .1f);
-                     
+
                         renderContext.gl.drawArrays(GL.POINTS, 0, mpcVertexBuffer[i].Count);
                     }
                 }
             }
-        }          
- 
+        }
 
-    
+
+
         private static void StartInit()
         {
             GetMpcFile(URL.FromCDN("wwtweb/catalog.aspx?Q=mpcbin"));
@@ -201,7 +201,7 @@ namespace wwtlib
             }
             finally
             {
-    
+
             }
         }
 

--- a/HTML5SDK/wwtlib/Place.cs
+++ b/HTML5SDK/wwtlib/Place.cs
@@ -253,9 +253,9 @@ namespace wwtlib
                     }
                     if (Classification == Classification.Star)
                     {
-                        return "//worldwidetelescope.org/wwtweb/thumbnail.aspx?name=star";
+                        return URLHelpers.FromWWW("wwtweb/thumbnail.aspx?name=star");
                     }
-                    return "//worldwidetelescope.org/wwtweb/thumbnail.aspx?name=" + name.ToLowerCase();
+                    return URLHelpers.FromWWW("wwtweb/thumbnail.aspx?name=" + name.ToLowerCase());
                 }
                 return this.thumbnailField;
             }

--- a/HTML5SDK/wwtlib/Place.cs
+++ b/HTML5SDK/wwtlib/Place.cs
@@ -244,7 +244,7 @@ namespace wwtlib
                     if (backgroundImageSet != null && !string.IsNullOrEmpty(backgroundImageSet.ThumbnailUrl))
                     {
                         return backgroundImageSet.ThumbnailUrl;
-                    }       
+                    }
                     string name = this.Name;
 
                     if (name.IndexOf(";") > -1)
@@ -452,7 +452,7 @@ namespace wwtlib
             {
                 xmlWriter.WriteStartElement("BackgroundImageSet");
                 Imageset.SaveToXml(xmlWriter, backgroundImageSet, "");
-                
+
                 xmlWriter.WriteEndElement();
             }
 
@@ -497,11 +497,11 @@ namespace wwtlib
             {
                 newPlace.constellation = place.Attributes.GetNamedItem("Constellation").Value;
             }
-        
+
             if (place.Attributes.GetNamedItem("Classification") != null)
             {
                 newPlace.classification = (Classification)Enums.Parse("Classification", place.Attributes.GetNamedItem("Classification").Value);
-          
+
             }
 
             if (place.Attributes.GetNamedItem("Magnitude") != null)

--- a/HTML5SDK/wwtlib/Planets.cs
+++ b/HTML5SDK/wwtlib/Planets.cs
@@ -48,7 +48,7 @@ namespace wwtlib
             Texture texture = new Texture();
 
             texture.Load(url);
-    
+
             return texture;
         }
 
@@ -301,7 +301,7 @@ namespace wwtlib
                     return "Ganymede";
                 case 13:
                     return "Callisto";
-                case 19: 
+                case 19:
                     return "Earth";
                 default:
                     return "";
@@ -906,7 +906,7 @@ namespace wwtlib
                 }
 
             }
-            
+
 
             return true;
         }
@@ -1699,7 +1699,7 @@ namespace wwtlib
 //        private static Matrix bias = Matrix.Scaling(new Vector3(.5f, .5f, .5f)) * Matrix.Translation(new Vector3(.5f, .5f, .5f));
         private static void DrawPlanet3d(RenderContext renderContext, int planetID, Vector3d centerPoint)
         {
-            
+
             if (planetID == (int)SolarSystemObjects.Sun)
             {
                 TileShader.MinLightingBrightness = 1.0f;
@@ -1848,7 +1848,7 @@ namespace wwtlib
                             //}
                             // todo saturns rings DrawRings(device);
                         }
-                        
+
                     }
 
                     if (planetID == 0)
@@ -1864,7 +1864,7 @@ namespace wwtlib
                         {
                             renderContext.Lighting = false;
                             DrawSaturnsRings(renderContext, true, dist);
-                            // DRAW FRONT HALF OF RINGS 
+                            // DRAW FRONT HALF OF RINGS
                             //if (Settings.Active.SolarSystemLighting)
                             //{
                             //    SetupRingShadow(device, centerPoint, SolarSystemObjects.Saturn, rotationCurrent);
@@ -2142,7 +2142,7 @@ namespace wwtlib
             }
             ringsVertexBuffer.Unlock();
         }
-    
+
 
         public static void DrawPointPlanet(RenderContext renderContext, Vector3d location, double size, Color color, bool zOrder)
         {
@@ -2417,9 +2417,9 @@ namespace wwtlib
             }
 
 
-         
 
-            // Special Case for Saturn and Eclipse 
+
+            // Special Case for Saturn and Eclipse
             //if (planetID == 18 || planetID == 5)
             //{
             //    double Width = rad*2;
@@ -2476,7 +2476,7 @@ namespace wwtlib
                     planetPoints[1].Tv = 0;
                     planetPoints[1].Color = Colors.White;
 
-                 
+
                     planetPoints[2].Position = Coordinates.RADecTo3dAu((planetPosition.RA + (raRadius / 15)), planetPosition.Dec + radius, 1);
                     planetPoints[2].Tu = 1;
                     planetPoints[2].Tv = 1;
@@ -2550,7 +2550,7 @@ namespace wwtlib
         private static void DrawPlanetPhase(RenderContext renderContext, int planetID, double phase, double angle, int dark)
         {
         }
-            
+
             //            //AstroRaDec planetPosition = planetLocations[planetID];
 
 //            //if (planetID < 10)
@@ -2806,7 +2806,7 @@ namespace wwtlib
 //            //    double lngMax = 180;
 
 
-//            //    // Create a vertex buffer 
+//            //    // Create a vertex buffer
 //            //    CustomVertex.PositionNormalTextured[] verts = (CustomVertex.PositionNormalTextured[])sphereVertexBuffers[sphereIndex].Lock(0, 0); // Lock the buffer (which will return our structs)
 //            //    int x1, y1;
 

--- a/HTML5SDK/wwtlib/Planets.cs
+++ b/HTML5SDK/wwtlib/Planets.cs
@@ -770,7 +770,7 @@ namespace wwtlib
         {
             return false;
             //string filename = Properties.Settings.Default.CahceDirectory + @"data\orbits.bin";
-            //DataSetManager.DownloadFile("//worldwidetelescope.org/wwtweb/catalog.aspx?Q=orbitsbin", filename, false, true);
+            //DataSetManager.DownloadFile(URLHelpers.FromWWW("wwtweb/catalog.aspx?Q=orbitsbin"), filename, false, true);
             //FileStream fs = null;
             //BinaryReader br = null;
             //long len = 0;
@@ -913,7 +913,7 @@ namespace wwtlib
 
         private static void LoadPlanetTextures()
         {
-            string baseUrl = "//worldwidetelescope.org/webclient/Images/";
+            string baseUrl = URLHelpers.FromWWW("webclient/Images/")
 
             planetTextures = new Texture[20];
             planetTextures[0] = LoadPlanetTexture(baseUrl + @"sun.png");

--- a/HTML5SDK/wwtlib/Planets.cs
+++ b/HTML5SDK/wwtlib/Planets.cs
@@ -913,7 +913,7 @@ namespace wwtlib
 
         private static void LoadPlanetTextures()
         {
-            string baseUrl = URLHelpers.FromWWW("webclient/Images/")
+            string baseUrl = URLHelpers.FromWWW("webclient/Images/");
 
             planetTextures = new Texture[20];
             planetTextures[0] = LoadPlanetTexture(baseUrl + @"sun.png");

--- a/HTML5SDK/wwtlib/Planets.cs
+++ b/HTML5SDK/wwtlib/Planets.cs
@@ -2103,7 +2103,7 @@ namespace wwtlib
             {
                 return;
             }
-            ringsTexture = Planets.LoadPlanetTexture(URL.FromCDN("webclient/images/SaturnRingsStrip.png"));
+            ringsTexture = Planets.LoadPlanetTexture(URLHelpers.FromCDN("webclient/images/SaturnRingsStrip.png"));
             double inner = 1.113;
             double outer = 2.25;
 

--- a/HTML5SDK/wwtlib/Planets.cs
+++ b/HTML5SDK/wwtlib/Planets.cs
@@ -2103,7 +2103,7 @@ namespace wwtlib
             {
                 return;
             }
-            ringsTexture = Planets.LoadPlanetTexture("//cdn.worldwidetelescope.org/webclient/images/SaturnRingsStrip.png");
+            ringsTexture = Planets.LoadPlanetTexture(URL.FromCDN("webclient/images/SaturnRingsStrip.png"));
             double inner = 1.113;
             double outer = 2.25;
 

--- a/HTML5SDK/wwtlib/SkyText.cs
+++ b/HTML5SDK/wwtlib/SkyText.cs
@@ -329,9 +329,9 @@ namespace wwtlib
         private GlyphCache(int height)
         {
             cellHeight = height;
-            texture = Planets.LoadPlanetTexture(URL.FromCDN("webclient/images/glyphs1.png"));
+            texture = Planets.LoadPlanetTexture(URLHelpers.FromCDN("webclient/images/glyphs1.png"));
 
-            webFile = new WebFile(URL.FromCDN("webclient/images/glyphs1.xml"));
+            webFile = new WebFile(URLHelpers.FromCDN("webclient/images/glyphs1.xml"));
             webFile.OnStateChange = GlyphXmlReady;
             webFile.Send();
         }

--- a/HTML5SDK/wwtlib/SkyText.cs
+++ b/HTML5SDK/wwtlib/SkyText.cs
@@ -38,7 +38,7 @@ namespace wwtlib
 
         public void Draw(RenderContext renderContext, float opacity, Color color)
         {
-          
+
 
             if (renderContext.gl == null)
             {
@@ -94,14 +94,14 @@ namespace wwtlib
 
 
                 TextShader.Use(renderContext, vertexBuffer.VertexBuffer, glyphCache.Texture.Texture2d);
- 
+
                 renderContext.gl.drawArrays(GL.TRIANGLES, 0, vertexBuffer.Count);
 
 
 
             }
         }
-       
+
         GlyphCache glyphCache;
 
         TextObject TextObject = new TextObject();
@@ -161,8 +161,8 @@ namespace wwtlib
                     }
                 }
 
-                Vector2d size = Vector2d.Create(width, height); 
- 
+                Vector2d size = Vector2d.Create(width, height);
+
                 t3d.width = size.X * (float)t3d.scale * factor * fntAdjust;
                 t3d.height = size.Y * (float)t3d.scale * factor * fntAdjust;
 
@@ -372,7 +372,7 @@ namespace wwtlib
         {
             get
             {
-              
+
 
                 return texture;
             }

--- a/HTML5SDK/wwtlib/SkyText.cs
+++ b/HTML5SDK/wwtlib/SkyText.cs
@@ -329,9 +329,9 @@ namespace wwtlib
         private GlyphCache(int height)
         {
             cellHeight = height;
-            texture = Planets.LoadPlanetTexture("//cdn.worldwidetelescope.org/webclient/images/glyphs1.png");
+            texture = Planets.LoadPlanetTexture(URL.FromCDN("webclient/images/glyphs1.png"));
 
-            webFile = new WebFile("//cdn.worldwidetelescope.org/webclient/images/glyphs1.xml");
+            webFile = new WebFile(URL.FromCDN("webclient/images/glyphs1.xml"));
             webFile.OnStateChange = GlyphXmlReady;
             webFile.Send();
         }

--- a/HTML5SDK/wwtlib/Tile.cs
+++ b/HTML5SDK/wwtlib/Tile.cs
@@ -26,7 +26,7 @@ namespace wwtlib
         public static int TileTargetLevel = -1;
 
         public int Level;
-       
+
         public int tileX;
 
         public int tileY;
@@ -48,7 +48,7 @@ namespace wwtlib
         protected Vector3d BottomLeft;
 
         public static double uvMultiple = 256;
-  
+
         public static List<Tile> GetFrustumList()
         {
             try
@@ -78,7 +78,7 @@ namespace wwtlib
 
         public Vector3d localCenter = new Vector3d();
         public int RenderedAtOrBelowGeneration = 0;
- 
+
         public void MakeTexture()
         {
             if (PrepDevice != null)
@@ -218,13 +218,13 @@ namespace wwtlib
                         RequestPending = false;
                         TileCache.RemoveFromQueue(this.Key, true);
                     }
-                    
+
                 }, false);
 
                 xdomimg.crossOrigin = "anonymous";
                 texture.Src = this.URL;
                 //texture.Src = "dss.png";
-                
+
                 // TODO add event listener for failed!
             }
         }
@@ -293,7 +293,7 @@ namespace wwtlib
                     catch
                     {
                     }
-                    
+
                     TileCache.RemoveFromQueue(this.Key, true);
                 }, false);
 
@@ -318,19 +318,19 @@ namespace wwtlib
         {
    //         CanvasContext2D device = renderContext.Device;
 
-            
+
 
             RenderedGeneration = CurrentRenderGeneration;
             TilesTouched++;
             AccessCount = TileCache.AccessID++;
- 
+
             if (errored)
             {
                 return false;
             }
- 
+
             int xMax = 2;
- 
+
             InViewFrustum = true;
 
             if (!ReadyToRender)
@@ -362,7 +362,7 @@ namespace wwtlib
                         //  if (level < (demEnabled ? 12 : dataset.Levels))
                         if (Level < dataset.Levels)
                         {
-                            // make children 
+                            // make children
                             if (children[childIndex] == null)
                             {
                                 children[childIndex] = TileCache.GetTile(Level + 1, tileX * 2 + ((x1 + xOffset) % 2), tileY * 2 + ((y1 + yOffset) % 2), dataset, this);
@@ -495,7 +495,7 @@ namespace wwtlib
         }
         public virtual void RenderPart(RenderContext renderContext, int part, double opacity, bool combine)
         {
-            
+
             if (PrepDevice == null)
             {
                 bool lighting = renderContext.Lighting && renderContext.SunPosition != null;
@@ -541,10 +541,10 @@ namespace wwtlib
                 renderContext.gl.drawElements(GL.TRIANGLES, TriangleCount * 3 , GL.UNSIGNED_SHORT, 0);
             }
         }
- 
+
         public virtual void CleanUp(bool removeFromParent)
         {
-            
+
             ReadyToRender = false;
             DemData = null;
             demFile = null;
@@ -583,12 +583,12 @@ namespace wwtlib
                 if (texture2d != null)
                 {
                     PrepDevice.deleteTexture(texture2d);
-      
+
                     texture2d = null;
                 }
             }
         }
-  
+
         public void RemoveChild(Tile child)
         {
             for (int i = 0; i < 4; i++)
@@ -603,7 +603,7 @@ namespace wwtlib
 
 //        bool blendMode = false;
 
-        
+
         public int AccessCount = 0;
         public bool Downloading = false;
         public bool GeometryCreated = false;
@@ -652,12 +652,12 @@ namespace wwtlib
 
         internal bool isHdTile = false;
         protected int demSize = 33 * 33;
-     
+
 
 
  //       public static Viewport Viewport;
         public static int maxLevel = 20;
-       
+
 
 
         Vector3d topLeftScreen = new Vector3d();
@@ -730,7 +730,7 @@ namespace wwtlib
 
             return true;
         }
-        
+
  //virtual public bool IsTileBigEnough(Device device)
  //       {
  //           //if (!IsTileInFrustum(frustum))
@@ -743,7 +743,7 @@ namespace wwtlib
  //           {
  //               if (this.Level < 25)
  //               {
- //                   deepestLevel = level > deepestLevel ? level : deepestLevel; 
+ //                   deepestLevel = level > deepestLevel ? level : deepestLevel;
  //                   return true;
  //                   bool a = true;
  //               }
@@ -829,7 +829,7 @@ namespace wwtlib
         //    }
         //    InViewFrustum = true;
 
-        //    return true;  
+        //    return true;
         //}
         virtual public bool IsTileInFrustum(PlaneD[] frustum)
         {
@@ -852,7 +852,7 @@ namespace wwtlib
             InViewFrustum = true;
 
             return true;
-        } 
+        }
 
 
         protected double sphereRadius;
@@ -870,7 +870,7 @@ namespace wwtlib
         {
             get { return sphereCenter; }
         }
- 
+
         protected const double RC = (3.1415927 / 180.0);
         protected float radius = 1;
         protected Vector3d GeoTo3d(double lat, double lng, bool useLocalCenter)
@@ -892,7 +892,7 @@ namespace wwtlib
             }
 
         }
-     
+
         static protected int SubDivisions
         {
             get { return 32; /*DemEnabled ? 32 : 16; */ }
@@ -907,7 +907,7 @@ namespace wwtlib
 
         public virtual void OnCreateVertexBuffer(object sender, EventArgs e)
         {
- 
+
         }
 
         public int RequestHits;
@@ -926,7 +926,7 @@ namespace wwtlib
             }
         }
 
-   
+
         public String Key
         {
             get
@@ -935,8 +935,8 @@ namespace wwtlib
             }
 
         }
-  
-    
+
+
         // URL parameters
         //{0} ImageSetID
         //{1} level
@@ -963,8 +963,8 @@ namespace wwtlib
         {
             get
             {
-            string returnUrl = dataset.Url;  
-                
+            string returnUrl = dataset.Url;
+
                 if (dataset.Url.IndexOf("{1}") > -1)
                 {
                     // Old style URL
@@ -1023,7 +1023,7 @@ namespace wwtlib
                     returnUrl = returnUrl.Replace("//r{S}.ortho.tiles.virtualearth.net", "//ecn.t{S}.tiles.virtualearth.net");
                 }
 
-                
+
                 string id = this.GetTileID();
                 string server = "";
 
@@ -1043,7 +1043,7 @@ namespace wwtlib
 
 
                 returnUrl = returnUrl.Replace("{Q}", id);
-                
+
                 returnUrl = returnUrl.Replace("{S}", server);
                 if (returnUrl.IndexOf("virtualearth.net") > -1)
                 {
@@ -1183,7 +1183,7 @@ namespace wwtlib
 
         protected int VertexCount
         {
-            get 
+            get
             {
 
                 return vertexCount;
@@ -1194,7 +1194,7 @@ namespace wwtlib
             }
         }
         BlendState[] renderChildPart = null;
-      
+
         public Tile()
         {
             renderChildPart = new BlendState[4];
@@ -1271,8 +1271,8 @@ namespace wwtlib
 //                PointInQuad(new PointF(rect.Left, rect.Bottom)))
 //            {
 //                return true;
-//            }   
-            
+//            }
+
 //            return false;
 //        }
 
@@ -1319,8 +1319,8 @@ namespace wwtlib
 //            return false;
 //        }
 //        /* (x1,y1),(x2,y2) defines a line.
-//* If the points (ax,ay) and (bx,by) are on 
-//* the same side of the line as each other, the 
+//* If the points (ax,ay) and (bx,by) are on
+//* the same side of the line as each other, the
 //* function returns 1. Otherwise it returns 0.
 //*/
 
@@ -1347,5 +1347,5 @@ namespace wwtlib
 //        }
 //    }
 
-    
+
 }

--- a/HTML5SDK/wwtlib/Tile.cs
+++ b/HTML5SDK/wwtlib/Tile.cs
@@ -222,7 +222,7 @@ namespace wwtlib
                 }, false);
 
                 xdomimg.crossOrigin = "anonymous";
-                texture.Src = this.URL.Replace("cdn.","www.");
+                texture.Src = this.URL;
                 //texture.Src = "dss.png";
                 
                 // TODO add event listener for failed!
@@ -1059,7 +1059,7 @@ namespace wwtlib
             {
                 if (dataset.Projection == ProjectionType.Mercator)
                 {
-                    string baseUrl = "//cdn.worldwidetelescope.org/wwtweb/demtile.aspx?q={0},{1},{2},M";
+                    string baseUrl = URL.FromCDN("wwtweb/demtile.aspx?q={0},{1},{2},M");
                     if (!String.IsNullOrEmpty(dataset.DemUrl))
                     {
                         baseUrl = dataset.DemUrl;

--- a/HTML5SDK/wwtlib/Tile.cs
+++ b/HTML5SDK/wwtlib/Tile.cs
@@ -1060,7 +1060,7 @@ namespace wwtlib
                 if (dataset.Projection == ProjectionType.Mercator)
                 {
                     string baseUrl;
-                    baseUrl = URL.FromCDN("wwtweb/demtile.aspx?q={0},{1},{2},M");
+                    baseUrl = URLHelpers.FromCDN("wwtweb/demtile.aspx?q={0},{1},{2},M");
                     if (!String.IsNullOrEmpty(dataset.DemUrl))
                     {
                         baseUrl = dataset.DemUrl;

--- a/HTML5SDK/wwtlib/Tile.cs
+++ b/HTML5SDK/wwtlib/Tile.cs
@@ -1059,7 +1059,8 @@ namespace wwtlib
             {
                 if (dataset.Projection == ProjectionType.Mercator)
                 {
-                    string baseUrl = URL.FromCDN("wwtweb/demtile.aspx?q={0},{1},{2},M");
+                    string baseUrl;
+                    baseUrl = URL.FromCDN("wwtweb/demtile.aspx?q={0},{1},{2},M");
                     if (!String.IsNullOrEmpty(dataset.DemUrl))
                     {
                         baseUrl = dataset.DemUrl;

--- a/HTML5SDK/wwtlib/Tour.cs
+++ b/HTML5SDK/wwtlib/Tour.cs
@@ -138,7 +138,7 @@ namespace wwtlib
                 }
                 else
                 {
-                    return String.Format("//worldwidetelescope.org/wwtweb/GetTourThumbnail.aspx?GUID={0}", Id);
+                    return String.Format(URLHelpers.FromWWW("wwtweb/GetTourThumbnail.aspx?GUID={0}", Id));
                 }
             }
             set

--- a/HTML5SDK/wwtlib/Tour.cs
+++ b/HTML5SDK/wwtlib/Tour.cs
@@ -154,7 +154,7 @@ namespace wwtlib
             {
                 if (string.IsNullOrEmpty(tourUrl))
                 {
-                    return string.Format("//cdn.worldwidetelescope.org/wwtweb/GetTour.aspx?GUID={0}", this.Id);
+                    return URL.FromCDN(string.Format("wwtweb/GetTour.aspx?GUID={0}", this.Id));
                 }
                 else
                 {

--- a/HTML5SDK/wwtlib/Tour.cs
+++ b/HTML5SDK/wwtlib/Tour.cs
@@ -138,7 +138,7 @@ namespace wwtlib
                 }
                 else
                 {
-                    return String.Format(URLHelpers.FromWWW("wwtweb/GetTourThumbnail.aspx?GUID={0}", Id));
+                    return String.Format(URLHelpers.FromWWW("wwtweb/GetTourThumbnail.aspx?GUID={0}"), Id);
                 }
             }
             set

--- a/HTML5SDK/wwtlib/Tour.cs
+++ b/HTML5SDK/wwtlib/Tour.cs
@@ -154,7 +154,7 @@ namespace wwtlib
             {
                 if (string.IsNullOrEmpty(tourUrl))
                 {
-                    return URL.FromCDN(string.Format("wwtweb/GetTour.aspx?GUID={0}", this.Id));
+                    return URLHelpers.FromCDN(string.Format("wwtweb/GetTour.aspx?GUID={0}", this.Id));
                 }
                 else
                 {

--- a/HTML5SDK/wwtlib/TourPlace.cs
+++ b/HTML5SDK/wwtlib/TourPlace.cs
@@ -238,9 +238,9 @@ namespace wwtlib
                     }
                     if (Classification == Classification.Star)
                     {
-                        return "http://cdn.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=star";
+                        return URL.FromCDN("wwtweb/thumbnail.aspx?name=star");
                     }
-                    return "http://cdn.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=" + name.ToLowerCase();
+                    return URL.FromCDN("wwtweb/thumbnail.aspx?name=" + name.ToLowerCase());
                 }
                 return this.thumbnailField;
             }

--- a/HTML5SDK/wwtlib/TourPlace.cs
+++ b/HTML5SDK/wwtlib/TourPlace.cs
@@ -238,9 +238,9 @@ namespace wwtlib
                     }
                     if (Classification == Classification.Star)
                     {
-                        return URL.FromCDN("wwtweb/thumbnail.aspx?name=star");
+                        return URLHelpers.FromCDN("wwtweb/thumbnail.aspx?name=star");
                     }
-                    return URL.FromCDN("wwtweb/thumbnail.aspx?name=" + name.ToLowerCase());
+                    return URLHelpers.FromCDN("wwtweb/thumbnail.aspx?name=" + name.ToLowerCase());
                 }
                 return this.thumbnailField;
             }

--- a/HTML5SDK/wwtlib/TourPlace.cs
+++ b/HTML5SDK/wwtlib/TourPlace.cs
@@ -229,7 +229,7 @@ namespace wwtlib
                     if (backgroundImageSet != null && !string.IsNullOrEmpty(backgroundImageSet.ThumbnailUrl))
                     {
                         return backgroundImageSet.ThumbnailUrl;
-                    }       
+                    }
                     string name = this.Name;
 
                     if (name.IndexOf(";") > -1)

--- a/HTML5SDK/wwtlib/URLHelpers.cs
+++ b/HTML5SDK/wwtlib/URLHelpers.cs
@@ -17,7 +17,7 @@ namespace wwtlib
         public string DEFAULT_HTTP_CDN = "cdn.worldwidetelescope.org";
         public string DEFAULT_HTTPS_CDN = "beta.worldwidetelescope.org";
 
-        public static Color FromCDN(string path)
+        public static string FromCDN(string path)
         {
 
             string protocol;

--- a/HTML5SDK/wwtlib/URLHelpers.cs
+++ b/HTML5SDK/wwtlib/URLHelpers.cs
@@ -27,13 +27,13 @@ namespace wwtlib
 
             switch (protocol) {
                 case "http":
-                    domain = URL.DEFAULT_HTTP_CDN;
+                    domain = DEFAULT_HTTP_CDN;
                     break;
                 case "https":
-                    domain = URL.DEFAULT_HTTPS_CDN;
+                    domain = DEFAULT_HTTPS_CDN;
                     break;
                 default:
-                    domain = URL.DEFAULT_HTTP_CDN;
+                    domain = DEFAULT_HTTP_CDN;
                     break;
             }
 

--- a/HTML5SDK/wwtlib/URLHelpers.cs
+++ b/HTML5SDK/wwtlib/URLHelpers.cs
@@ -10,10 +10,6 @@ namespace wwtlib
 {
     public class URLHelpers
     {
-        public float A = 255.0f;
-        public float B = 255.0f;
-        public float G = 255.0f;
-        public float R = 255.0f;
         public static string DEFAULT_HTTP_CDN = "cdn.worldwidetelescope.org";
         public static string DEFAULT_HTTPS_CDN = "beta.worldwidetelescope.org";
 
@@ -26,10 +22,10 @@ namespace wwtlib
             protocol = (string)Script.Literal("window.location.protocol");
 
             switch (protocol) {
-                case "http":
+                case "http:":
                     domain = DEFAULT_HTTP_CDN;
                     break;
-                case "https":
+                case "https:":
                     domain = DEFAULT_HTTPS_CDN;
                     break;
                 default:

--- a/HTML5SDK/wwtlib/URLHelpers.cs
+++ b/HTML5SDK/wwtlib/URLHelpers.cs
@@ -63,5 +63,37 @@ namespace wwtlib
 
         }
 
+        public static string Patch(string url)
+        {
+
+            string protocol;
+            protocol = (string)Script.Literal("window.location.protocol");
+
+            if (protocol == 'http:') {
+                return url;
+            }
+
+            if (url.StartsWith("http://worldwidetelescope.org")) {
+                url = url.Replace("http://worldwidetelescope.org/", "");
+                return FromWWW(url);
+            }
+
+            if (url.StartsWith("http://www.worldwidetelescope.org")) {
+                url = url.Replace("http://www.worldwidetelescope.org/", "");
+                return FromWWW(url);
+            }
+
+            if (url.StartsWith("http://cdn.worldwidetelescope.org")) {
+                url = url.Replace("http://cdn.worldwidetelescope.org/", "");
+                return FromCDN(url);
+            }
+
+            if (url.StartsWith("http://")) {
+                url = url.Replace("http://", "https://");
+                return url;
+            }
+
+        }
+
     }
 }

--- a/HTML5SDK/wwtlib/URLHelpers.cs
+++ b/HTML5SDK/wwtlib/URLHelpers.cs
@@ -10,10 +10,10 @@ namespace wwtlib
 {
     public class URLHelpers
     {
-        public static string DEFAULT_HTTP_CDN = "cdn.worldwidetelescope.org";
-        public static string DEFAULT_HTTPS_CDN = "beta.worldwidetelescope.org";
-        public static string DEFAULT_HTTP_WWW = "www.worldwidetelescope.org";
-        public static string DEFAULT_HTTPS_WWW = "beta.worldwidetelescope.org";
+
+        // NOTE: we deliberately don't define the default URLs as static
+        // properties here since they end up not being set in time for some
+        // calls to FromCDN and FromWWT
 
         public static string FromCDN(string path)
         {
@@ -25,13 +25,13 @@ namespace wwtlib
 
             switch (protocol) {
                 case "http:":
-                    domain = DEFAULT_HTTP_CDN;
+                    domain = "cdn.worldwidetelescope.org";
                     break;
                 case "https:":
-                    domain = DEFAULT_HTTPS_CDN;
+                    domain = "beta.worldwidetelescope.org";
                     break;
                 default:
-                    domain = DEFAULT_HTTP_CDN;
+                    domain = "cdn.worldwidetelescope.org";
                     break;
             }
 
@@ -49,13 +49,13 @@ namespace wwtlib
 
             switch (protocol) {
                 case "http:":
-                    domain = DEFAULT_HTTP_WWW;
+                    domain = "www.worldwidetelescope.org";
                     break;
                 case "https:":
-                    domain = DEFAULT_HTTPS_WWW;
+                    domain = "beta.worldwidetelescope.org";
                     break;
                 default:
-                    domain = DEFAULT_HTTP_WWW;
+                    domain = "www.worldwidetelescope.org";
                     break;
             }
 

--- a/HTML5SDK/wwtlib/URLHelpers.cs
+++ b/HTML5SDK/wwtlib/URLHelpers.cs
@@ -90,8 +90,9 @@ namespace wwtlib
 
             if (url.StartsWith("http://")) {
                 url = url.Replace("http://", "https://");
-                return url;
             }
+
+            return url;
 
         }
 

--- a/HTML5SDK/wwtlib/URLHelpers.cs
+++ b/HTML5SDK/wwtlib/URLHelpers.cs
@@ -69,7 +69,7 @@ namespace wwtlib
             string protocol;
             protocol = (string)Script.Literal("window.location.protocol");
 
-            if (protocol == 'http:') {
+            if (protocol == "http:") {
                 return url;
             }
 

--- a/HTML5SDK/wwtlib/URLHelpers.cs
+++ b/HTML5SDK/wwtlib/URLHelpers.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace wwtlib
 {
-    public class URL
+    public class URLHelpers
     {
         public float A = 255.0f;
         public float B = 255.0f;

--- a/HTML5SDK/wwtlib/URLHelpers.cs
+++ b/HTML5SDK/wwtlib/URLHelpers.cs
@@ -27,13 +27,13 @@ namespace wwtlib
 
             switch (protocol) {
                 case "http":
-                    domain = DEFAULT_HTTP_CDN;
+                    domain = URL.DEFAULT_HTTP_CDN;
                     break;
                 case "https":
-                    domain = DEFAULT_HTTPS_CDN;
+                    domain = URL.DEFAULT_HTTPS_CDN;
                     break;
                 default:
-                    domain = DEFAULT_HTTP_CDN;
+                    domain = URL.DEFAULT_HTTP_CDN;
                     break;
             }
 

--- a/HTML5SDK/wwtlib/URLHelpers.cs
+++ b/HTML5SDK/wwtlib/URLHelpers.cs
@@ -1,0 +1,45 @@
+﻿// This contains a helper class 'CDN' which is used to create CDN URLs
+// and allow the SDK caller to customize them.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+
+namespace wwtlib
+{
+    public class URL
+    {
+        public float A = 255.0f;
+        public float B = 255.0f;
+        public float G = 255.0f;
+        public float R = 255.0f;
+        public string DEFAULT_HTTP_CDN = "cdn.worldwidetelescope.org";
+        public string DEFAULT_HTTPS_CDN = "beta.worldwidetelescope.org";
+
+        public static Color FromCDN(string path)
+        {
+
+            string protocol;
+            string domain;
+
+            protocol = (string)Script.Literal("window.location.protocol");
+
+            switch (protocol) {
+                case "http":
+                    domain = DEFAULT_HTTP_CDN;
+                    break;
+                case "https":
+                    domain = DEFAULT_HTTPS_CDN;
+                    break;
+                case default:
+                    domain = DEFAULT_HTTP_CDN;
+                    break;
+            }
+
+            return "//" + domain + "/" + path;
+
+        }
+
+    }
+}

--- a/HTML5SDK/wwtlib/URLHelpers.cs
+++ b/HTML5SDK/wwtlib/URLHelpers.cs
@@ -12,6 +12,8 @@ namespace wwtlib
     {
         public static string DEFAULT_HTTP_CDN = "cdn.worldwidetelescope.org";
         public static string DEFAULT_HTTPS_CDN = "beta.worldwidetelescope.org";
+        public static string DEFAULT_HTTP_WWW = "www.worldwidetelescope.org";
+        public static string DEFAULT_HTTPS_WWW = "beta.worldwidetelescope.org";
 
         public static string FromCDN(string path)
         {
@@ -30,6 +32,30 @@ namespace wwtlib
                     break;
                 default:
                     domain = DEFAULT_HTTP_CDN;
+                    break;
+            }
+
+            return "//" + domain + "/" + path;
+
+        }
+
+        public static string FromWWW(string path)
+        {
+
+            string protocol;
+            string domain;
+
+            protocol = (string)Script.Literal("window.location.protocol");
+
+            switch (protocol) {
+                case "http:":
+                    domain = DEFAULT_HTTP_WWW;
+                    break;
+                case "https:":
+                    domain = DEFAULT_HTTPS_WWW;
+                    break;
+                default:
+                    domain = DEFAULT_HTTP_WWW;
                     break;
             }
 

--- a/HTML5SDK/wwtlib/URLHelpers.cs
+++ b/HTML5SDK/wwtlib/URLHelpers.cs
@@ -14,8 +14,8 @@ namespace wwtlib
         public float B = 255.0f;
         public float G = 255.0f;
         public float R = 255.0f;
-        public string DEFAULT_HTTP_CDN = "cdn.worldwidetelescope.org";
-        public string DEFAULT_HTTPS_CDN = "beta.worldwidetelescope.org";
+        public static string DEFAULT_HTTP_CDN = "cdn.worldwidetelescope.org";
+        public static string DEFAULT_HTTPS_CDN = "beta.worldwidetelescope.org";
 
         public static string FromCDN(string path)
         {

--- a/HTML5SDK/wwtlib/URLHelpers.cs
+++ b/HTML5SDK/wwtlib/URLHelpers.cs
@@ -32,7 +32,7 @@ namespace wwtlib
                 case "https":
                     domain = DEFAULT_HTTPS_CDN;
                     break;
-                case default:
+                default:
                     domain = DEFAULT_HTTP_CDN;
                     break;
             }

--- a/HTML5SDK/wwtlib/Util.cs
+++ b/HTML5SDK/wwtlib/Util.cs
@@ -142,7 +142,7 @@ namespace wwtlib
 
             if (url.ToLowerCase().StartsWith("http"))
             {
-                return "//worldwidetelescope.org/webserviceproxy.aspx?targeturl=" + url.EncodeUriComponent();
+                return URLHelpers.FromWWW("webserviceproxy.aspx?targeturl=" + url.EncodeUriComponent());
             }
             return url;
         }
@@ -176,7 +176,7 @@ namespace wwtlib
 
         public static string GetTourComponent(string url, string name)
         {
-            return "//worldwidetelescope.org/GetTourFile.aspx?targeturl=" + url.EncodeUriComponent() + "&filename=" + name;
+            return URLHelpers.FromWWW("GetTourFile.aspx?targeturl=" + url.EncodeUriComponent() + "&filename=" + name);
         }
 
         public static string XMLDate(Date d)

--- a/HTML5SDK/wwtlib/Util.cs
+++ b/HTML5SDK/wwtlib/Util.cs
@@ -103,19 +103,19 @@ namespace wwtlib
 
 
             //    return RegularExpression.Parse(name + "=" + "(.+?)(&|$)").Exec(Document.URL.Search)||[,null])[1]
-            //           function getURLParameter(name) { 
-            //    return decodeURI( 
-            //        (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,null])[1] 
-            //    ); 
-            //} 
+            //           function getURLParameter(name) {
+            //    return decodeURI(
+            //        (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,null])[1]
+            //    );
+            //}
 
             //            RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,null])[1]
 
-            //                "[?&]"+name+"=([^&]*)" 
+            //                "[?&]"+name+"=([^&]*)"
 
             return "";
         }
-                
+
 
         public static string GetProxiedUrl(string url)
         {
@@ -438,7 +438,7 @@ namespace wwtlib
 
     public class Guid
     {
-  
+
         string guid = Create();
 
         public Guid()
@@ -1744,7 +1744,7 @@ namespace wwtlib
                 this.Next = true;
             }
         }
-        
+
         private bool _return = false;
         public bool ReturnCaller
         {
@@ -1765,7 +1765,7 @@ namespace wwtlib
             {
                 if (value)
                 {
-                    _slide = "Next";                    
+                    _slide = "Next";
                 }
                 _next = value;
             }

--- a/HTML5SDK/wwtlib/WWTControl.cs
+++ b/HTML5SDK/wwtlib/WWTControl.cs
@@ -717,7 +717,7 @@ namespace wwtlib
             Script.SetTimeout(delegate () { Render(); }, 10);
         }
 
-        
+
         private string GetCurrentReferenceFrame()
         {
             if (RenderContext.BackgroundImageset == null)
@@ -923,7 +923,7 @@ namespace wwtlib
 
         private const double DragCoefficient = 0.8;
 
-       
+
         private void UpdateViewParameters()
         {
             if (RenderContext.Space && tracking && trackingObject != null)
@@ -1004,8 +1004,8 @@ namespace wwtlib
                 //    }
                 //}
                 //else
-                
-               
+
+
                     //if (!Settings.Current.SmoothPan)
                     //{
                     //    this.viewCamera.Lat = this.targetCamera.Lat;
@@ -1386,9 +1386,9 @@ namespace wwtlib
             canvas.AddEventListener("touchend", OnTouchEnd, false);
             canvas.AddEventListener("gesturechange", OnGestureChange, false);
             canvas.AddEventListener("gesturestart", OnGestureStart, false);
-            canvas.AddEventListener("gestureend", OnGestureEnd, false);  
-            Document.Body.AddEventListener("keydown", OnKeyDown, false); 
-            //canvas.AddEventListener("MSGestureChange", OnGestureChange, false);  
+            canvas.AddEventListener("gestureend", OnGestureEnd, false);
+            Document.Body.AddEventListener("keydown", OnKeyDown, false);
+            //canvas.AddEventListener("MSGestureChange", OnGestureChange, false);
             //canvas.AddEventListener("mouseout", OnMouseUp, false);
 
             // MS Touch code
@@ -1485,7 +1485,7 @@ namespace wwtlib
         {
             GestureEvent g = (GestureEvent)e;
             mouseDown = false;
-         
+
         }
 
         private bool Annotationclicked(double ra, double dec, double x, double y)
@@ -1588,7 +1588,7 @@ namespace wwtlib
 
 
             mouseDown = true;
-    
+
         }
 
         int[] pointerIds = new int[2];
@@ -1768,7 +1768,7 @@ namespace wwtlib
 
         Vector2d[] rect = new Vector2d[2];
         public void pinchStart(TouchEvent ev)
-        {        
+        {
             TouchInfo t0 = ev.Touches[0];
             TouchInfo t1 = ev.Touches[1];
             rect[0] = Vector2d.Create( t0.PageX,  t0.PageY );
@@ -1802,7 +1802,7 @@ namespace wwtlib
 
         public double GetDistance(Vector2d a, Vector2d b)
         {
-            
+
             double x;
             double y;
             x = a.X - b.X;
@@ -1817,7 +1817,7 @@ namespace wwtlib
         public void OnMouseDown(ElementEvent e)
         {
             // Capture mouse
-            
+
 
             Document.AddEventListener("mousemove", OnMouseMove, false);
             Document.AddEventListener("mouseup", OnMouseUp, false);
@@ -1839,13 +1839,13 @@ namespace wwtlib
         {
             e.PreventDefault();
             e.StopPropagation();
-            
+
         }
 
 
         public void OnMouseMove(ElementEvent e)
         {
-           
+
             lastMouseMove = Date.Now;
             hoverTextPoint = Vector2d.Create( Mouse.OffsetX(Canvas, e), Mouse.OffsetY(Canvas, e));
             hoverText = "";
@@ -1898,7 +1898,7 @@ namespace wwtlib
             {
                 RenderContext.TargetCamera.Angle = 0;
             }
-         
+
         }
         bool moved = false;
         public void OnMouseUp(ElementEvent e)
@@ -1925,7 +1925,7 @@ namespace wwtlib
             mouseDown = false;
 
             moved = false;
-            
+
         }
 
         public Vector2d GetCoordinatesForScreenPoint(double x, double y)
@@ -1936,7 +1936,7 @@ namespace wwtlib
             Vector2d pt = Vector2d.Create(x, y);
             PickRayDir = TransformPickPointToWorldSpace(pt, RenderContext.Width, RenderContext.Height);
             result = Coordinates.CartesianToSphericalSky(PickRayDir);
-            
+
             return result;
         }
 
@@ -2036,7 +2036,7 @@ namespace wwtlib
 
 
                 //todo remove this line to turn WebGL on...
-                webGL = true; 
+                webGL = true;
 
                 if (webGL)
                 {
@@ -2060,7 +2060,7 @@ namespace wwtlib
                 {
                     Tile.PrepDevice = gl;
                     Singleton.RenderContext.gl = gl;
-                 
+
                     RenderContext.UseGl = true;
                 }
 
@@ -2104,7 +2104,7 @@ namespace wwtlib
                      "//worldwidetelescope.org/wwtweb/thumbnail.aspx?name=earth",
                      true, false, 0, 0, 0, "", "", "", "", 6371000, "Earth");
                 }
-               
+
                 //if (StartMode == "bing")
                 //{
                 //    Singleton.RenderContext.BackgroundImageset =
@@ -2123,7 +2123,7 @@ namespace wwtlib
 
             Singleton.RenderContext.ViewCamera.Lng += 0;
 
-            
+
             Singleton.RenderContext.InitGL();
 
 
@@ -2560,7 +2560,7 @@ namespace wwtlib
             RenderContext.ViewCamera = RenderContext.TargetCamera.Copy();
             Mover = null;
         }
-        
+
 
         internal IViewMover Mover
         {
@@ -2701,10 +2701,10 @@ namespace wwtlib
 
             tour = new TourDocument();
             tour.Title = name;
-          
+
             SetupTour();
             tour.EditMode = true;
-    
+
             return tour;
         }
 
@@ -2735,12 +2735,12 @@ namespace wwtlib
                         //uiController = player;
                         //WWTControl.scriptInterface.FireTourReady();
                         //player.Play();
-                        
+
                         SetupTour();
                         TourEdit.PlayNow(true);
                         WWTControl.scriptInterface.FireTourReady();
                     });
-            
+
         }
 
         public void PlayCurrentTour()
@@ -2842,11 +2842,11 @@ namespace wwtlib
             }
         }
 
- 
+
         public void CaptureThumbnail(BlobReady blobReady)
         {
             Render();
-           
+
             ImageElement image = (ImageElement)Document.CreateElement("img");
             image.AddEventListener("load", delegate (ElementEvent e)
             {

--- a/HTML5SDK/wwtlib/WWTControl.cs
+++ b/HTML5SDK/wwtlib/WWTControl.cs
@@ -825,7 +825,7 @@ namespace wwtlib
             {
                 if (constellationsFigures == null)
                 {
-                    constellationsFigures = Constellations.Create("Constellations", "//worldwidetelescope.org/data/figures.txt", false, false, false);
+                    constellationsFigures = Constellations.Create("Constellations", URLHelpers.FromWWW("data/figures.txt"), false, false, false);
                     //constellationsFigures = Constellations.Create("Constellations", "//localhost/data/figures.txt", false, false, false);
                 }
 
@@ -887,7 +887,7 @@ namespace wwtlib
             {
                 if (constellationsBoundries == null)
                 {
-                    constellationsBoundries = Constellations.Create("Constellations", "//worldwidetelescope.org/data/constellations.txt", true, false, false);
+                    constellationsBoundries = Constellations.Create("Constellations", URLHelpers.FromWWW("data/constellations.txt"), true, false, false);
                     //constellationsBoundries = Constellations.Create("Constellations", "//localhost/data/constellations.txt", true, false, false);
                 }
                 constellationsBoundries.Draw(RenderContext, Settings.Active.ShowConstellationSelection, Constellation, false);
@@ -1416,9 +1416,9 @@ namespace wwtlib
                 fgDevice = (CanvasContext2D)foregroundCanvas.GetContext(Rendering.Render2D);
             }
             webFolder = new Folder();
-            webFolder.LoadFromUrl("//worldwidetelescope.org/wwtweb/catalog.aspx?X=ImageSets5", SetupComplete);
+            webFolder.LoadFromUrl(URLHelpers.FromWWW("wwtweb/catalog.aspx?X=ImageSets5"), SetupComplete);
 
-            WebFile webFile = new WebFile("//worldwidetelescope.org/wwtweb/weblogin.aspx?user=12345678-03D2-4935-8D0F-DCE54C9113E5&Version=HTML5&webkey=AX2011Gqqu&platform=web");
+            WebFile webFile = new WebFile(URLHelpers.FromWWW("wwtweb/weblogin.aspx?user=12345678-03D2-4935-8D0F-DCE54C9113E5&Version=HTML5&webkey=AX2011Gqqu&platform=web"));
             webFile.Send();
         }
 
@@ -1449,7 +1449,7 @@ namespace wwtlib
 
 
                 ExploreRoot = new Folder();
-                ExploreRoot.LoadFromUrl("//worldwidetelescope.org/wwtweb/catalog.aspx?W=NewExploreRoot",
+                ExploreRoot.LoadFromUrl(URLHelpers.FromWWW("wwtweb/catalog.aspx?W=NewExploreRoot"),
                     delegate { Explorer.AddItems(WWTControl.ExploreRoot.Children); Explorer.Refresh(); });
             }
         }
@@ -2076,7 +2076,7 @@ namespace wwtlib
                     URLHelpers.FromCDN("wwtweb/dss.aspx?q={1},{2},{3}"),
                     ImageSetType.Sky, BandPass.Visible, ProjectionType.Toast, 100,
                     0, 12, 256, 180, ".png", false, "", 0, 0, 0, false,
-                    "//worldwidetelescope.org/thumbnails/DSS.png",
+                    URLHelpers.FromWWW("thumbnails/DSS.png"),
                     true, false, 0, 0, 0, "", "", "", "", 1, "Sky");
 
 
@@ -2085,10 +2085,10 @@ namespace wwtlib
                     Singleton.RenderContext.BackgroundImageset =
                         Imageset.Create(
                         "Blue Marble",
-                        "//worldwidetelescope.org/wwtweb/tiles.aspx?q={1},{2},{3},bm200407",
+                        URLHelpers.FromWWW("/wwtweb/tiles.aspx?q={1},{2},{3},bm200407"),
                         ImageSetType.Earth, BandPass.Visible, ProjectionType.Toast, 101,
                         0, 7, 256, 180, ".png", false, "", 0, 0, 0, false,
-                        "//worldwidetelescope.org/wwtweb/thumbnail.aspx?name=bm200407",
+                        URLHelpers.FromWWW("wwtweb/thumbnail.aspx?name=bm200407"),
                         true, false, 0, 0, 0, "", "", "", "", 6371000, "Earth");
 
 
@@ -2101,7 +2101,7 @@ namespace wwtlib
                      "//a{0}.ortho.tiles.virtualearth.net/tiles/a{1}.jpeg?g=15",
                      ImageSetType.Earth, BandPass.Visible, ProjectionType.Mercator, 102,
                      1, 20, 256, 360, ".png", false, "0123", 0, 0, 0, false,
-                     "//worldwidetelescope.org/wwtweb/thumbnail.aspx?name=earth",
+                    URLHelpers.FromWWW("/wwtweb/thumbnail.aspx?name=earth"),
                      true, false, 0, 0, 0, "", "", "", "", 6371000, "Earth");
                 }
 

--- a/HTML5SDK/wwtlib/WWTControl.cs
+++ b/HTML5SDK/wwtlib/WWTControl.cs
@@ -2073,7 +2073,7 @@ namespace wwtlib
                 Singleton.RenderContext.BackgroundImageset =
                     Imageset.Create(
                     "DSS",
-                    "//cdn.worldwidetelescope.org/wwtweb/dss.aspx?q={1},{2},{3}",
+                    URL.FromCDN("wwtweb/dss.aspx?q={1},{2},{3}"),
                     ImageSetType.Sky, BandPass.Visible, ProjectionType.Toast, 100,
                     0, 12, 256, 180, ".png", false, "", 0, 0, 0, false,
                     "//worldwidetelescope.org/thumbnails/DSS.png",

--- a/HTML5SDK/wwtlib/WWTControl.cs
+++ b/HTML5SDK/wwtlib/WWTControl.cs
@@ -2073,7 +2073,7 @@ namespace wwtlib
                 Singleton.RenderContext.BackgroundImageset =
                     Imageset.Create(
                     "DSS",
-                    URL.FromCDN("wwtweb/dss.aspx?q={1},{2},{3}"),
+                    URLHelpers.FromCDN("wwtweb/dss.aspx?q={1},{2},{3}"),
                     ImageSetType.Sky, BandPass.Visible, ProjectionType.Toast, 100,
                     0, 12, 256, 180, ".png", false, "", 0, 0, 0, false,
                     "//worldwidetelescope.org/thumbnails/DSS.png",

--- a/HTML5SDK/wwtlib/wwtlib.csproj
+++ b/HTML5SDK/wwtlib/wwtlib.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Tours\Undo.cs" />
     <Compile Include="Triangle.cs" />
     <Compile Include="UiTools.cs" />
+    <Compile Include="URLHelpers.cs" />
     <Compile Include="Util.cs" />
     <Compile Include="Utilities\BinaryReader.cs" />
     <Compile Include="Utilities\Bitmap.cs" />


### PR DESCRIPTION
The aim of this PR is to provide a central place (``URLHelpers``) where we set/patch the domain for URLs, which allows us to switch the URLs to use e.g. beta.worldwidetelescope.org if the current protocol is https.

In future we could also provide API calls to change the domains to use on-the-fly.