### PR TITLE
Add different "build profiles"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist/
 /node_modules/
 /package-lock.json
+/profile-localtest.yml
 /wwtsdk.js

--- a/README.md
+++ b/README.md
@@ -73,17 +73,22 @@ npm install
 Once that has been done, you can build the website with:
 
 ```
-grunt dist-all
+grunt dist-dev
 ```
 
 Then, we recommend running:
 
 ```
-npx http-server dist/
+npx http-server dist
 ```
 
 This server (and most other static-file servers) will print out a URL that you
 can visit to test out the web client locally.
+
+There are also `dist-prod` and `dist-localtest` tasks that configure the build
+slightly differently. In particular, by creating a `profile-localtest.yml`
+file derived from `profile-dev.yml`, you can monkey with some low-level
+settings if you need to do so for testing purposes.
 
 
 ## Acknowledgments

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
 - task: Grunt@0
   inputs:
     gruntFile: 'Gruntfile.js'
-    targets: 'dist-all'
+    targets: 'dist-prod'  # TEMPORARY: should differ depending on dev/prod
   displayName: Build distribution directory with Grunt
 
 - task: CopyFiles@2

--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
     <meta property="og:description" content="Worldwide Telescope enables your computer to function as a virtual telescope, bringing together imagery from the best earth and space-based telescopes." />
     <meta property="og:image" content="https://worldwidetelescope.org/webclient/Images/wwtlogo.png" />
     <link rel="icon" href="favicon.ico"/>
-    <link href="css/webclient.min.css?v=<%= shortSHA %>" rel="stylesheet" />
-    <link href="css/angular-motion.css?v=<%= shortSHA %>" rel="stylesheet" />
-    <link href="css/introjs.css?v=<%= shortSHA %>" rel="stylesheet" />
+    <link href="<%= webclient_static_assets_url_prefix %>css/webclient<%= maybe_min %>.css?v=<%= shortSHA %>" rel="stylesheet" />
+    <link href="<%= webclient_static_assets_url_prefix %>css/angular-motion.css?v=<%= shortSHA %>" rel="stylesheet" />
+    <link href="<%= webclient_static_assets_url_prefix %>css/introjs.css?v=<%= shortSHA %>" rel="stylesheet" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/style/jquery.jscrollpane.css" rel="stylesheet"/>
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"/>
     <!-- Global Site Tag (gtag.js) - Google Analytics -->
@@ -26,12 +26,12 @@
     </script>
     <style>
       body .finder-scope {
-        background: url(Images/finder-scope.png?v=<%= shortSHA %>) no-repeat;
+        background: url(<%= webclient_static_assets_url_prefix %>Images/finder-scope.png?v=<%= shortSHA %>) no-repeat;
       }
     </style>
     <script src="//js.live.net/v5.0/wl.js"></script>
     <script src="//code.jquery.com/jquery-3.4.1.min.js"></script>
-    <script src="//beta-cdn.worldwidetelescope.org/engine/latest/wwtsdk.js?v=<%= shortSHA %>"></script> <!-- TEMPORARY -->
+    <script src="<%= webgl_engine_url_prefix %>/wwtsdk<%= maybe_min %>.js"></script>
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular-touch.min.js"></script>
@@ -43,7 +43,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pako/1.0.3/pako_inflate.min.js"></script>
-    <script src="wwtwebclient.js?v=<%= shortSHA %>"></script>
+    <script src="<%= webclient_static_assets_url_prefix %>wwtwebclient<%= maybe_min %>.js?v=<%= shortSHA %>"></script>
   </head>
   <body
     class="fs-player wwt-webclient-wrapper desktop"
@@ -141,8 +141,8 @@
 
       </script>
 
-      <ng-include src="'views/research-menu.html?v=<%= shortSHA %>'"></ng-include>
-      <ng-include src="'views/modals/finder-scope.html?v=<%= shortSHA %>'" onload="initFinder()"></ng-include>
+      <ng-include src="'<%= webclient_static_assets_url_prefix %>views/research-menu.html?v=<%= shortSHA %>'"></ng-include>
+      <ng-include src="'<%= webclient_static_assets_url_prefix %>views/modals/finder-scope.html?v=<%= shortSHA %>'" onload="initFinder()"></ng-include>
 
 
       <div data-ng-controller="ViewController"></div>
@@ -160,11 +160,11 @@
           </a>
         </span>
 
-        <a class="btn pull-right" href="/Download/" target="wwt">
+        <a class="btn pull-right" href="<%= userweb_url_prefix %>/Download/" target="wwt">
           <i class="fa fa-download"></i>
           <span localize="Install Windows Client"></span>
         </a>
-        <a class="home-icon" href="/home">
+        <a class="home-icon" href="<%= userweb_url_prefix %>/home">
           <i class="fa fa-home"></i>
         </a>
         <ul class="wwt-tabs">
@@ -202,7 +202,7 @@
           <span ng-repeat="bc in breadCrumb" class="bc"><a href="javascript:void(0)" ng-click="breadCrumbClick($index)">{{bc}}</a>&nbsp;>&nbsp;</span><br />
           <div class="explore-thumbs">
             <div class="ribbon-thumbs" ng-repeat="item in collectionPage">
-              <ng-include src="'views/thumbnail.html?v=<%= shortSHA %>'"></ng-include>
+              <ng-include src="'<%= webclient_static_assets_url_prefix %>views/thumbnail.html?v=<%= shortSHA %>'"></ng-include>
             </div>
 
           </div>
@@ -276,7 +276,7 @@
           </div>
           <div class="search-results">
             <div class="ribbon-thumbs" ng-repeat="item in collectionPage">
-              <ng-include src="'views/thumbnail.html?v=<%= shortSHA %>'"></ng-include>
+              <ng-include src="'<%= webclient_static_assets_url_prefix %>views/thumbnail.html?v=<%= shortSHA %>'"></ng-include>
             </div>
           </div>
           <label class="wwt-pager" ng-show="collection.length > 0">
@@ -304,7 +304,7 @@
           <span ng-repeat="bc in breadCrumb" class="bc"><a href="javascript:void(0)" ng-click="breadCrumbClick($index)">{{bc}}</a>&nbsp;>&nbsp;</span><br />
           <div class="explore-thumbs">
             <div class="ribbon-thumbs" ng-repeat="item in collectionPage">
-              <ng-include src="'views/thumbnail.html?v=<%= shortSHA %>'"></ng-include>
+              <ng-include src="'<%= webclient_static_assets_url_prefix %>views/thumbnail.html?v=<%= shortSHA %>'"></ng-include>
             </div>
 
           </div>
@@ -362,7 +362,7 @@
             <a class="btn" bs-popover
                localize="Observing Time"
                localize-only="title"
-               data-content-template="views/popovers/observing-time.html?v=<%= shortSHA %>"
+               data-content-template="<%= webclient_static_assets_url_prefix %>views/popovers/observing-time.html?v=<%= shortSHA %>"
                ng-controller="ObservingTimeController"
                data-animation="am-flip-x"
                data-placement="bottom-right">
@@ -496,12 +496,12 @@
                   <div class="stops-container">
                     <a class="btn" bs-popover
                        style="position:absolute;top:110px;left:190px;visibility:hidden"
-                       template-url="views/popovers/tour-properties.html?v=<%= shortSHA %>"
+                       template-url="<%= webclient_static_assets_url_prefix %>views/popovers/tour-properties.html?v=<%= shortSHA %>"
                        trigger="click" placement="bottom-left" data-content="{tour}"
                        data-container="body" id="newTourProps"></a>
                     <div class="stop-arrow" ng-repeat="stop in tourStops">
                       <div class="transition-choice {{stop.transHover ? 'active' : ''}}"
-                           bs-popover template-url="views/popovers/transition-type.html?v=<%= shortSHA %>"
+                           bs-popover template-url="<%= webclient_static_assets_url_prefix %>views/popovers/transition-type.html?v=<%= shortSHA %>"
                            trigger="click" placement="bottom-left" data-content="{1}"
                            title="Transition" data-container="body" data-auto-close="true"
                            data-on-show="testfn()" data-on-hide="testfn()">
@@ -572,17 +572,17 @@
               <td class="edit-panel">
                 <div ng-if="editingTour" class="edit-panel">
                   <script src="//cdnjs.cloudflare.com/ajax/libs/tinymce/4.4.1/tinymce.min.js"></script>
-                  <link href="css/skin.min.css" rel="stylesheet" />
+                  <link href="<%= webclient_static_assets_url_prefix %>css/skin.min.css" rel="stylesheet" />
                   <div class="left">
                     <a class="btn" bs-popover
                        localize="Tour Properties" style="width:98px;"
-                       template-url="views/popovers/tour-properties.html?v=<%= shortSHA %>"
+                       template-url="<%= webclient_static_assets_url_prefix %>views/popovers/tour-properties.html?v=<%= shortSHA %>"
                        trigger="click" placement="bottom-left" data-content="{tour}"
                        title="Tour Properties" data-container="body"></a>
                     <a class="btn" localize="Save" style="width:48px;" ng-click="saveTour()"></a>
 
                     <div>
-                      <a class="btn menu-button text" bs-modal template-url="views/popovers/tour-text.html?v=<%= shortSHA %>"
+                      <a class="btn menu-button text" bs-modal template-url="<%= webclient_static_assets_url_prefix %>views/popovers/tour-text.html?v=<%= shortSHA %>"
                          trigger="click" data-content="{tour}" id="editTourText" placement="center"
                          title="Enter Text" data-container="body">
                         <div class="icon">
@@ -658,7 +658,7 @@
             </tr>
           </table>
 
-          <ng-include src="'views/popovers/slide-overlays.html?v=<%= shortSHA %>'"></ng-include>
+          <ng-include src="'<%= webclient_static_assets_url_prefix %>views/popovers/slide-overlays.html?v=<%= shortSHA %>'"></ng-include>
 
         </div>
       </div>
@@ -753,7 +753,7 @@
             style="position:absolute; top:6px;left:-33px;z-index:3"
             localize="Share this view"
             localize-only="title"
-            data-content-template="views/popovers/shareplace.html?v=<%= shortSHA %>"
+            data-content-template="<%= webclient_static_assets_url_prefix %>views/popovers/shareplace.html?v=<%= shortSHA %>"
             data-container="body"
             data-placement="top-right"
             >
@@ -837,7 +837,7 @@
         </div>
         <div class="thumbnails nearby-objects rel" ng-if="!compressed" data-ng-controller="ContextPanelController" ng-style="{width: bottomControlsWidth()}">
           <div class="rel" style="display: inline-block;vertical-align:top;" ng-repeat="item in collectionPage" ng-if="lookAt != 'Planet' && lookAt != 'Panorama'">
-            <ng-include src="'views/thumbnail.html?v=<%= shortSHA %>'"></ng-include>
+            <ng-include src="'<%= webclient_static_assets_url_prefix %>views/thumbnail.html?v=<%= shortSHA %>'"></ng-include>
           </div>
           <label class="wwt-pager">
             <a class="btn"
@@ -846,7 +846,7 @@
                style="position:absolute; top:0;right:-204px"
                localize="Share this view"
                localize-only="title"
-               data-content-template="views/popovers/shareplace.html?v=<%= shortSHA %>"
+               data-content-template="<%= webclient_static_assets_url_prefix %>views/popovers/shareplace.html?v=<%= shortSHA %>"
                data-container="body"
                data-placement="top-right"
                >
@@ -859,7 +859,7 @@
                  style="position:absolute; top:0;left:-40px"
                  localize="Share this place"
                  localize-only="title"
-                 data-content-template="views/popovers/shareplace.html?v=<%= shortSHA %>"
+                 data-content-template="<%= webclient_static_assets_url_prefix %>views/popovers/shareplace.html?v=<%= shortSHA %>"
                  data-container="body"
                  data-placement="top-right"
                  >
@@ -880,13 +880,13 @@
 
       </div>
 
-      <ng-include src="'views/modals/intro.html?v=<%= shortSHA %>'"></ng-include>
+      <ng-include src="'<%= webclient_static_assets_url_prefix %>views/modals/intro.html?v=<%= shortSHA %>'"></ng-include>
       <div class="modal" id="loadingModal" tabindex="-1" role="dialog" aria-labelledby="loadingModalLabel" aria-hidden="true">
         <div class="modal-dialog">
           <div class="modal-content">
 
             <div class="modal-body">
-              <img src='Images/wwtlogo.png'
+              <img src='<%= webclient_static_assets_url_prefix %>Images/wwtlogo.png'
                    style="width:19%;height:19%;position:relative;left:-3px;margin-right:12px;"
                    class="pull-left"
                    localize="WorldWide Telescope Logo"
@@ -920,7 +920,7 @@
       </div>
 
       <a href="javascript:void(0)" data-toggle="modal" data-target="#loadingModal" id="loadingModalLink">&nbsp;</a>
-      <ng-include src="'views/modals/open-item.html?v=<%= shortSHA %>'"></ng-include>
+      <ng-include src="'<%= webclient_static_assets_url_prefix %>views/modals/open-item.html?v=<%= shortSHA %>'"></ng-include>
       <div ng-intro-autostart="false"
            ng-intro-onbeforechange="beforeChange"
            ng-intro-onafterchange="afterChange"

--- a/profile-dev.yml
+++ b/profile-dev.yml
@@ -1,0 +1,10 @@
+# Copyright 2020 the .NET Foundation
+# Licensed under the MIT License
+
+# See `profile-prod.yml` for documentation of the uses of these parameters.
+# This files gives parameters suitable for development.
+
+webclient_static_assets_url_prefix: ''
+userweb_url_prefix: https://beta.worldwidetelescope.org
+webgl_engine_url_prefix: https://beta-cdn.worldwidetelescope.org/engine/latest
+maybe_min: ''

--- a/profile-prod.yml
+++ b/profile-prod.yml
@@ -1,0 +1,29 @@
+# Copyright 2020 the .NET Foundation
+# Licensed under the MIT License
+
+# A prefix to prepend to paths for static assets (i.e. virtually everything!)
+# associated with this webclient instantiation. On the production server, we
+# want to make it Go Faster by routing requests to such assets through the
+# CDN. On development servers, we want references to these items to be
+# relative URLs for testing flexibility.
+webclient_static_assets_url_prefix: https://beta-cdn.worldwidetelescope.org/webclient/
+
+# A prefix to prepend to paths for links to the "user website", which will look
+# like "/Download" before prefixing. On the production server, we're being
+# served from /webclient/ and they're in the root, so:
+userweb_url_prefix: ..
+
+# The URL prefix for finding the Web engine. In production, we want to route
+# this through the CDN. In development we want to use the testing version or
+# perhaps even a local hacked version.
+#
+# XXX TEMPORARY: we should point at a fixed version in production, but for now
+# we're pointing at the "latest" version since we're iterating quickly.
+webgl_engine_url_prefix: https://beta-cdn.worldwidetelescope.org/engine/latest
+
+# This string gets munged into CSS and JS references to potentially referenced
+# minified versions ("foo.min.js") instead of un-minified ("foo.js")
+#
+# XXX TEMPORARY: during beta-testing of the new web framework, we're not
+# using minified versions to help debugging.
+maybe_min: ''


### PR DESCRIPTION
By using the Grunt task `profile:dev` or `profile:prod`, we can load different variable settings from YAML files and insert them into index.html and/or app.js. This lets us tune the specific build for local testing or the production server (where we want to use the CDN), and using YAML files makes it reproducible. Pretty pleased with how this turned out.

Primary motivation was pulling in webclient static asset files over the CDN, rather than getting them from relative URLs. (Since the origin will be wwt.o, not cdn.wwt.o.)