### PR TITLE
Start using wwtassets.org for webclient and webgl-engine static assets.

### DIFF
--- a/profile-dev.yml
+++ b/profile-dev.yml
@@ -8,7 +8,7 @@ webclient_static_assets_url_prefix: ''
 userweb_url_prefix: //beta.worldwidetelescope.org
 communities_url_prefix: //beta.worldwidetelescope.org
 core_static_url_prefix: //beta.worldwidetelescope.org/
-webgl_engine_url_prefix: //beta.worldwidetelescope.org/engine/latest  # no CDN to avoid staleness issues
+webgl_engine_url_prefix: //wwtwebstatic.z22.web.core.windows.net/engine/latest  # no CDN to avoid staleness issues
 maybe_min: ''
 microsoft_live_oauth_app_id: ''
 microsoft_live_oauth_redir_url: ''

--- a/profile-prod.yml
+++ b/profile-prod.yml
@@ -6,7 +6,7 @@
 # want to make it Go Faster by routing requests to such assets through the
 # CDN. On development servers, we want references to these items to be
 # relative URLs for testing flexibility.
-webclient_static_assets_url_prefix: //beta-cdn.worldwidetelescope.org/webclient/
+webclient_static_assets_url_prefix: //web.wwtassets.org/webclient/
 
 # A prefix to prepend to paths for links to the "user website", which will look
 # like "/Download" before prefixing. On the production server, we're being
@@ -30,7 +30,7 @@ core_static_url_prefix: //beta-cdn.worldwidetelescope.org/
 #
 # XXX TEMPORARY: we should point at a fixed version in production, but for now
 # we're pointing at the "latest" version since we're iterating quickly.
-webgl_engine_url_prefix: //beta-cdn.worldwidetelescope.org/engine/latest
+webgl_engine_url_prefix: //web.wwtassets.org/engine/latest
 
 # This string gets munged into CSS and JS references to potentially referenced
 # minified versions ("foo.min.js") instead of un-minified ("foo.js")


### PR DESCRIPTION
The motivation here is that (beta-)cdn.worldwidetelescope.org is always going to have to route its requests through worldwidetelescope.org, which means they will have to go through the App Gateway reverse proxy before eventually being routed to wwtwebstatic (in the case of webclient static assets).

The new web.wwtassets.org is a CDN endpoint that points straight at the wwtwebstatic static website service. By using this new endpoint, we cut out the App Gateway middleman, which should reduce load on that service, hopefully be faster, and hopefully save us some money.

Like most big-ticket websites, we use a separate second-level domain, namely the new wwtassets.org. The apparent motivation is that that way you don't have the cookies from your main website making their way into every single one of your asset requests. I'd also like to think that it helps maintain clarity between the traffic that gets routed through the App Gateway and everything else. The domain is $13/yr right now so it feels easily worthwhile.