### PR TITLE
Version 6.0.1: fixup for preproduction testing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,8 +30,9 @@ module.exports = function (grunt) {
     // in Git for reproducibility.
     profile: {
       dev: 'profile-dev.yml',
+      localtest: 'profile-localtest.yml',
       prod: 'profile-prod.yml',
-      localtest: 'profile-localtest.yml'
+      testing: 'profile-testing.yml',
     },
 
     // Task configuration.
@@ -239,7 +240,7 @@ module.exports = function (grunt) {
     'copy:dist'
   ];
 
-  for (let profname of ['dev', 'localtest', 'prod']) {
+  for (let profname of ['dev', 'localtest', 'prod', 'testing']) {
     grunt.registerTask('dist-' + profname, ['profile:' + profname].concat(all_tasks));
   }
 };

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,9 +20,11 @@ steps:
     if($branch.StartsWith("refs/tags/v")) {
       $version = $branch.Substring(11)
       Write-Host "##vso[task.setvariable variable=pub_prefix;]webclient"
+      Write-Host "##vso[task.setvariable variable=profile;]prod"
     } else {
       # Won't actually get published on PRs, etc.
       Write-Host "##vso[task.setvariable variable=pub_prefix;]testing_webclient"
+      Write-Host "##vso[task.setvariable variable=profile;]testing"
     }
   displayName: Set deployment parameters
 
@@ -35,7 +37,7 @@ steps:
   displayName: Build distribution directory with Grunt
   inputs:
     gruntFile: 'Gruntfile.js'
-    targets: 'dist-prod'  # NOTE: due to our setup, we want this even for merges to `master`
+    targets: 'dist-$(profile)'
 
 - task: CopyFiles@2
   displayName: Copy dist directory to artifact staging

--- a/profile-testing.yml
+++ b/profile-testing.yml
@@ -1,0 +1,15 @@
+# Copyright 2020 the .NET Foundation
+# Licensed under the MIT License
+
+# See `profile-prod.yml` for documentation of the uses of these parameters.
+# This files gives parameters used for continuous deployment of the repository's
+# `master` branch, which is made available at worldwidetelescope.org/testing_webclient/
+
+webclient_static_assets_url_prefix: //wwtwebstatic.z22.web.core.windows.net/testing_webclient/
+userweb_url_prefix: ..
+communities_url_prefix: ..
+core_static_url_prefix: //cdn.worldwidetelescope.org/
+webgl_engine_url_prefix: //wwtwebstatic.z22.web.core.windows.net/engine/6.0
+maybe_min: '.min'
+microsoft_live_oauth_app_id: ''  # '000000004015657B'
+microsoft_live_oauth_redir_url: 'http://www.worldwidetelescope.org/webclient'


### PR DESCRIPTION
I had thought that we could use all the settings for production in the new /testing_webclient/ publication endpoint, but (duh) we have to change webclient_static_assets_url_prefix. So now we have a new "testing" profile for that.