### PR TITLE
Jump onto the 7.0 series of the WebGL engine

### DIFF
--- a/controllers/LayerManagerController.js
+++ b/controllers/LayerManagerController.js
@@ -502,7 +502,7 @@ wwt.controllers.controller(
       };
 
       var formatDateTime = function(d) {
-        return ss.format('{0:yyyy/MM/dd}', d) + ss.format(' {0:HH:mm:ss}',d);
+        return wwtlib.ss.format('{0:yyyy/MM/dd}', d) + wwtlib.ss.format(' {0:HH:mm:ss}',d);
       }
 
       $scope.setTimeSeries = function(layer,enable) {

--- a/controllers/MainController.js
+++ b/controllers/MainController.js
@@ -191,18 +191,6 @@ wwt.controllers.controller(
         update_window_size();
 
         ctl = $rootScope.ctl = wwtlib.WWTControl.initControlParam("WWTCanvas", appState.get('WebGl'));
-
-        // The .8 release of scriptsharp changed the location of the canCast function
-        // This logic exists to ensure backwards compatibility when testing an older version
-        // of the framework.
-        if (window.Type && Type.canCast) {
-          if (window.ss) {
-            window.ss.canCast = Type.canCast;
-          } else {
-            window.ss = {canCast: Type.canCast};
-          }
-        }
-
         wwt.wc = ctl;
 
         ctl.add_ready(function () {
@@ -743,7 +731,7 @@ wwt.controllers.controller(
         }
         $scope.setTrackingObj(item);
 
-        if (!item.isSurvey && ss.canCast(item, wwtlib.Place)) {
+        if (!item.isSurvey && wwtlib.ss.canCast(item, wwtlib.Place)) {
           $('.finder-scope').hide();
           //$('.cross-fader').parent().toggle(imageSet!=null);
           $rootScope.singleton.gotoTarget(item, false, !!$rootScope.instant, true);

--- a/controllers/tabs/ExploreController.js
+++ b/controllers/tabs/ExploreController.js
@@ -167,7 +167,7 @@
 
         col.forEach(function(place) {
 
-          if (ss.canCast(place, wwtlib.Place) &&
+          if (wwtlib.ss.canCast(place, wwtlib.Place) &&
               place.annotation && place.annotation.length) {
             hasAnnotations = true;
             var opts = uiLib.annotationOpts(place.annotation);

--- a/controllers/tabs/ToursController.js
+++ b/controllers/tabs/ToursController.js
@@ -47,7 +47,7 @@
 			}
 			
 			
-			if (ss.canCast(item, wwtlib.Tour)) {
+			if (wwtlib.ss.canCast(item, wwtlib.Tour)) {
 				$scope.playTour(item.get_tourUrl());
 				if ($rootScope.is_mobile) {
 					$rootScope.landscapeMessage = true;

--- a/dataproxy/SearchData.js
+++ b/dataproxy/SearchData.js
@@ -119,7 +119,7 @@
 
               if (item.name === 'SolarSystem') {
                 $.each(pl, function (k, member) {
-                  if (ss.canCast(member, wwtlib.CameraParameters)) {
+                  if (wwtlib.ss.canCast(member, wwtlib.CameraParameters)) {
                     member.target = wwtlib.SolarSystemObjects.undefined;
                   }
                 });

--- a/factories/SearchUtil.js
+++ b/factories/SearchUtil.js
@@ -124,7 +124,7 @@
 
 	    var searchPlaces = ssPlaces.concat(constellationPlaces);
 	    var results = [];
-            var ss = [];
+            var solsys = [];
             var imgsets = [];
 
 	    $.each(searchPlaces, function(i, place) {
@@ -136,7 +136,7 @@
 		    place.fromCenter = placeDist.length();
 
 		    if (place.get_constellation() === 'SolarSystem') {
-		      ss.push(place)
+		      solsys.push(place)
                     } else if (place.get_studyImageset()) {
 		      imgsets.push(place);
                     } else {
@@ -149,8 +149,8 @@
 	      }
 	    });
 
-	    ss = ss.sort(sortByImagery);
-	    deferred.resolve(ss.concat(imgsets.sort(sortByImagery), results.sort(sortByImagery)));
+	    solsys = solsys.sort(sortByImagery);
+	    deferred.resolve(solsys.concat(imgsets.sort(sortByImagery), results.sort(sortByImagery)));
 	  } else {
 	    deferred.resolve([]);
 	  }

--- a/factories/ThumbList.js
+++ b/factories/ThumbList.js
@@ -225,11 +225,11 @@ wwt.app.factory(
           }
         }
 
-        if ((ss.canCast(item, wwtlib.Place) || item.isEarth) && !item.isSurvey) {
+        if ((wwtlib.ss.canCast(item, wwtlib.Place) || item.isEarth) && !item.isSurvey) {
           scope.setForegroundImage(item);
         }
 
-        if (ss.canCast(item, wwtlib.Tour)) {
+        if (wwtlib.ss.canCast(item, wwtlib.Tour)) {
           scope.playTour(item.get_tourUrl());
         }
 

--- a/factories/Util.js
+++ b/factories/Util.js
@@ -260,11 +260,11 @@
       function getImageset(place) {
 	if (!place) {
 	  return null;
-	} else if (ss.canCast(place, wwtlib.Imageset)) {
+	} else if (wwtlib.ss.canCast(place, wwtlib.Imageset)) {
 	  return place;
-	} else if (place.get_backgroundImageset && ss.canCast(place.get_backgroundImageset(), wwtlib.Imageset)) {
+	} else if (place.get_backgroundImageset && wwtlib.ss.canCast(place.get_backgroundImageset(), wwtlib.Imageset)) {
 	  return place.get_backgroundImageset();
-	} else if (place.get_studyImageset && ss.canCast(place.get_studyImageset(), wwtlib.Imageset)) {
+	} else if (place.get_studyImageset && wwtlib.ss.canCast(place.get_studyImageset(), wwtlib.Imageset)) {
 	  return place.get_studyImageset();
 	} else {
 	  return null;

--- a/profile-prod.yml
+++ b/profile-prod.yml
@@ -27,7 +27,7 @@ core_static_url_prefix: //cdn.worldwidetelescope.org/
 # The URL prefix for finding the Web engine. In production, we want to route
 # this through the CDN. In development we want to use the testing version or
 # perhaps even a local hacked version.
-webgl_engine_url_prefix: //web.wwtassets.org/engine/6.0
+webgl_engine_url_prefix: //web.wwtassets.org/engine/7.0
 
 # This string gets munged into CSS and JS references to potentially referenced
 # minified versions ("foo.min.js") instead of un-minified ("foo.js").

--- a/profile-testing.yml
+++ b/profile-testing.yml
@@ -9,7 +9,7 @@ webclient_static_assets_url_prefix: //web.wwtassets.org/testing_webclient/
 userweb_url_prefix: ..
 communities_url_prefix: ..
 core_static_url_prefix: //cdn.worldwidetelescope.org/
-webgl_engine_url_prefix: //web.wwtassets.org/engine/6.0
+webgl_engine_url_prefix: //web.wwtassets.org/engine/7.0
 maybe_min: '.min'
 microsoft_live_oauth_app_id: '000000004015657B'
 microsoft_live_oauth_redir_url: 'http://worldwidetelescope.org/webclient'


### PR DESCRIPTION
The 7.0 series is a big infrastructure jump, turning the engine into a real NPM package that can be imported, adding TypeScript bindings, and wiring up real documentation. But from the webclient perspective, the only difference so far is that the `ss` name now lives within the `wwtlib` object, rather than having an independent existence.