### PR TITLE
Release 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aas-worldwide-telescope-webclient",
     "description": "AAS WorldWide Telescope web client",
-    "version": "6.1.0",
+    "version": "6.1.1-beta.0",
     "keywords": [
         "AAS WorldWide Telescope"
     ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aas-worldwide-telescope-webclient",
     "description": "AAS WorldWide Telescope web client",
-    "version": "6.0.7",
+    "version": "6.1.0",
     "keywords": [
         "AAS WorldWide Telescope"
     ],


### PR DESCRIPTION
This switches the webclient to start using the 7.x series of the underlying WebGL engine, which massively updates the engine build infrastructure but not actually the core code.