### PR TITLE
controllers/MainController.js: attempt to fix #316

### DIFF
--- a/controllers/MainController.js
+++ b/controllers/MainController.js
@@ -578,6 +578,21 @@ wwt.controllers.controller(
           finderMoved = true;
 
       $scope.showFinderScope = function (event) {
+        // On Windows, right-click brings up the finder scope and control-click
+        // rolls the view. On Macs, control-click brings up the context menu --
+        // i.e., the same action as a right-click. This function is triggered by
+        // contextmenu events, so it gets called for either action. Without
+        // special handling, this means that an attempt to roll the view also
+        // pulls up the finder scope, which is annoying. Here we ignore events
+        // triggered when the control key is held down. Note this means that Mac
+        // users with a single-button mouse won't be able to pull up the finder
+        // scope. That feels like an OK price to pay.
+        if (event.originalEvent && event.originalEvent.ctrlKey) {
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
+
         if ($scope.lookAt === 'Sky' && !$scope.editingTour) {
           var finder = $('.finder-scope');
           var wasHidden = (finder.prop('display') == 'none');


### PR DESCRIPTION
Currently, on a Mac, if you try to roll the view with a control-drag, it also pops up the finder scope. Here we try to prevent this in a somewhat hacky way. It might be better to preserve the Mac semantics that control-click = context menu, but that would require selecting a different mouse gesture for rolling the camera.

Closes #316.