### PR TITLE
Increase precision of RA readouts

### DIFF
--- a/controllers/MainController.js
+++ b/controllers/MainController.js
@@ -527,7 +527,7 @@ wwt.controllers.controller(
           }
 
           $scope.formatted = {
-            RA: util.formatHms(viewport.RA, true),
+            RA: util.formatHms(viewport.RA, true, false, false, 1),
             Dec: util.formatHms(viewport.Dec, false, true),
             Lat: util.formatHms($scope.coords.get_lat(), false, false),
             Lng: util.formatHms(lng/*$scope.coords.get_lng()*/, false, false),
@@ -1061,8 +1061,8 @@ wwt.controllers.controller(
       //#endregion
 
       //#region view helpers
-      $scope.formatHms = function (angle, isHmsFormat, signed, spaced) {
-        return util.formatHms(angle, isHmsFormat, signed, spaced);
+      $scope.formatHms = function (angle, isHmsFormat, signed, spaced, extraPrecision) {
+        return util.formatHms(angle, isHmsFormat, signed, spaced, extraPrecision);
       };
 
       $scope.formatDecimalHours = function (dayFraction, spaced) {

--- a/factories/Util.js
+++ b/factories/Util.js
@@ -102,20 +102,53 @@
         return (n >= 0) ? Math.floor(n) : Math.ceil(n);
       }
 
-      function formatHms(angle, isHmsFormat, signed, spaced) {
-        var minutes = (angle - truncate(angle)) * 60;
-        var seconds = (minutes - truncate(minutes)) * 60;
-        minutes = Math.abs(minutes);
-        seconds = Math.abs(seconds);
+      function formatHms(angle, isHmsFormat, signed, spaced, extraPrecision) {
+        var sign = '';
 
-        var join = spaced ? ' : ' : ':';
-        if (isNaN(angle)) {
-          angle = minutes = seconds = 0;
+        if (angle < 0) {
+          sign = '-';
+          angle = -angle;
+        } else if (signed) {
+          sign = '+';
         }
-        return isHmsFormat ? int2(angle) + 'h'
-          + int2(minutes) + 'm'
-          + int2(seconds) + 's' :
-          ([signed && angle > 0 ? '+' + int2(angle) : int2(angle), int2(minutes), int2(seconds)]).join(join);
+
+        var seps = [':', ':', ''];
+
+        if (isHmsFormat) {
+          seps = ['h', 'm', 's'];
+        } else if (spaced) {
+          seps = [' : ', ' : ', ''];
+        }
+
+        var values = ['??', '??', '??'];
+
+        if (!isNaN(angle)) {
+          var hourlike = Math.floor(angle);
+          var remainder = (angle - hourlike) * 60;
+          var minutes = Math.floor(remainder);
+          var seconds = (remainder - minutes) * 60;
+
+          values[0] = hourlike.toFixed(0);
+          if (hourlike < 10) {
+            values[0] = '0' + values[0];
+          }
+
+          values[1] = minutes.toFixed(0);
+          if (minutes < 10) {
+            values[1] = '0' + values[1];
+          }
+
+          if (isNaN(extraPrecision)) {
+            extraPrecision = 0;
+          }
+
+          values[2] = seconds.toFixed(extraPrecision);
+          if (seconds < 10) {
+            values[2] = '0' + values[2];
+          }
+        }
+
+        return sign.concat(values[0], seps[0], values[1], seps[1], values[2], seps[2]);
       };
 
       function parseHms(input) {

--- a/views/modals/finder-scope.html
+++ b/views/modals/finder-scope.html
@@ -10,7 +10,7 @@
 			<h4><strong localize="Names"></strong>: <span>{{scopePlace.get_names()?scopePlace.get_names().join(', '): scopePlace.get_name()}}</span></h4>
 			<hr />
 			<div style="width:48%;display:inline-block" ng-if="!scopePlace.isSurvey">
-				<p><label localize="RA"></label>: <span>{{formatHms(scopePlace.get_RA(), true)}}</span></p>
+				<p><label localize="RA"></label>: <span>{{formatHms(scopePlace.get_RA(), true, false, false, 1)}}</span></p>
 				<p><label localize="Dec"></label>: <span>{{formatHms(scopePlace.get_dec(), false, true, true)}}</span></p>
 				<p><label localize="Alt"></label>: <span>{{formatHms(scopePlace.altAz.get_alt(), false, false, true)}}</span></p>
 				<p><label localize="Az"></label>: <span>{{formatHms(scopePlace.altAz.get_az(), false, false, true)}}</span></p>

--- a/views/popovers/property-panel.html
+++ b/views/popovers/property-panel.html
@@ -18,7 +18,7 @@
   <hr />
 
   <div style="width:48%;display:inline-block" ng-if="!propertyItem.isSurvey">
-    <p><label localize="RA"></label>: <span>{{formatHms(propertyItem.get_RA(), true)}}</span></p>
+    <p><label localize="RA"></label>: <span>{{formatHms(propertyItem.get_RA(), true, false, false, 1)}}</span></p>
     <p><label localize="Dec"></label>: <span>{{formatHms(propertyItem.get_dec(), false, true, true)}}</span></p>
     <p><label localize="Alt"></label>: <span>{{formatHms(propertyItem.altAz.get_alt(), false, false, true)}}</span></p>
     <p><label localize="Az"></label>: <span>{{formatHms(propertyItem.altAz.get_az(), false, false, true)}}</span></p>


### PR DESCRIPTION
Usual practice is to provide an extra decimal place of RA precision compared to Dec, since hours are more than 10 times coarse-grained than degrees. Do this by adding a new `extraPrecision` argument to `formatHms`. Also generally tidy up that implementation.

Closes #326.