### PR TITLE
controllers/LoginController.js: attempt to fix OAuth redirection

### DIFF
--- a/controllers/LoginController.js
+++ b/controllers/LoginController.js
@@ -13,7 +13,7 @@ wwt.controllers.controller(
         if (util.getQSParam('code') != null) {
           var returnUrl = location.href.split('?')[0];
           location.href = $rootScope.communitiesUrlPrefix + '/LiveId/AuthenticateFromCode/' + util.getQSParam('code') +
-            '?returnUrl=' + encodeURIComponent(returnUrl);
+            '/?returnUrl=' + encodeURIComponent(returnUrl);
         } else if ($cookies.get('access_token')) {
           $rootScope.loggedIn = true;
           $rootScope.token = $cookies.get('access_token');


### PR DESCRIPTION
The Microsoft Live OAuth codes now contain period characters, which break the way that we were passing data to the AuthenticateFromCode API. But it looks like we can fix it by just adding a final slash to the URL that we construct.