### PR TITLE
Work on display of planetary imagery

### DIFF
--- a/controllers/tabs/ExploreController.js
+++ b/controllers/tabs/ExploreController.js
@@ -10,7 +10,7 @@
     'ThumbList',
     'UILibrary',
 
-    function ($scope, $rootScope, appState, places, $timeout, util,  thumbList, uiLib) {
+    function ($scope, $rootScope, appState, places, $timeout, util, thumbList, uiLib) {
       var exploreRoot;
       var depth = 1;
       var bc;

--- a/factories/ThumbList.js
+++ b/factories/ThumbList.js
@@ -215,17 +215,22 @@ wwt.app.factory(
         } else if (item.isEarth) {
           scope.setLookAt('Earth', item.get_name());
         } else if (util.getIsPlanet(item)) {
-          if (scope.lookAt === 'Sky') {
+          if (scope.lookAt === 'Sky' && wwtlib.ss.canCast(item, wwtlib.Place)) {
             wwtlib.WWTControl.singleton.gotoTarget3(item.get_camParams());
             return outParams;
           }
 
           if (scope.lookAt !== 'SolarSystem') {
-            scope.setLookAt('Planet', item._name || '');
+            scope.setLookAt('Planet', item._name || '', true, item.isSurvey);
           }
+
+          // Planetary imagesets have to be handled specially. We have to set
+          // them as the *background* as well as the foreground to render
+          // properly.
+          scope.setBackgroundImage(item);
         }
 
-        if ((wwtlib.ss.canCast(item, wwtlib.Place) || item.isEarth) && !item.isSurvey) {
+        if ((wwtlib.ss.canCast(item, wwtlib.Place) || wwtlib.ss.canCast(item, wwtlib.Imageset) || item.isEarth) && !item.isSurvey) {
           scope.setForegroundImage(item);
         }
 


### PR DESCRIPTION
There are a couple of bugfixes here for pieces of code that assumed that an "item" was a Place when it might also be an imageset.

The main change is an attempt to clean up the code to load planetary imagery. This imagery has to be loaded as a background imageset due to the way the engine works. But that caused a lot of problems because a lot of the "lookAt" related code assumes that background imagesets are only going to be in the pre-defined lists of imagery. Furthermore, the lookAt code involves a bunch of timeouts that easily induce race conditions.

Here we add a `lookAtFoundImagery` guard to attempt to avoid the race where the lookAt initialization process stomps on a later explicit assignment of the background imagery.

We also don't default the imageryName to "Mars" if we're not changing lookAt due to an explicit click of the dropdown menu.

We also add new background imagesets to the imagery UI list to prevent the lookAt code from overriding the settings. This isn't great but it's the only workable solution I could come up with. It has a particular weakness where the new items in the UI won't necessarily be functional since we have no way to add them to the engine's table of known imagesets.