### PR TITLE
index.html: load pako and uuid early for updated webgl-engine

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,8 @@
     </style>
 
     <script src="//code.jquery.com/jquery-3.4.1.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pako/1.0.3/pako_inflate.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/uuid/8.3.2/uuid.min.js"></script>
     <script src="<%= webgl_engine_url_prefix %>/wwtsdk<%= maybe_min %>.js"></script>
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.8/angular.min.js"></script>
@@ -52,7 +54,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-strap/2.3.8/angular-strap.tpl.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/pako/1.0.3/pako_inflate.min.js"></script>
     <script src="<%= webclient_static_assets_url_prefix %>wwtwebclient<%= maybe_min %>.js?v=<%= shortSHA %>"></script>
   </head>
 


### PR DESCRIPTION
We need to have these loaded up before `wwtsdk.js` in order for the new module-loading code to properly detect them.