### PR TITLE
Fix bug in formatHms that can show seconds value of 60

### DIFF
--- a/factories/Util.js
+++ b/factories/Util.js
@@ -128,6 +128,22 @@
           var minutes = Math.floor(remainder);
           var seconds = (remainder - minutes) * 60;
 
+          if (isNaN(extraPrecision)) {
+            extraPrecision = 0;
+          }
+          var secondsStr = seconds.toFixed(extraPrecision);
+
+          if (secondsStr.startsWith('60')) {
+            seconds = 0;
+            secondsStr = '0';
+            minutes += 1;
+
+            if (minutes == 60) {
+              minutes = 0;
+              hourlike += 1;
+            }
+          }
+
           values[0] = hourlike.toFixed(0);
           if (hourlike < 10) {
             values[0] = '0' + values[0];
@@ -138,11 +154,7 @@
             values[1] = '0' + values[1];
           }
 
-          if (isNaN(extraPrecision)) {
-            extraPrecision = 0;
-          }
-
-          values[2] = seconds.toFixed(extraPrecision);
+          values[2] = secondsStr;
           if (seconds < 10) {
             values[2] = '0' + values[2];
           }

--- a/factories/Util.js
+++ b/factories/Util.js
@@ -135,7 +135,7 @@
 
           if (secondsStr.startsWith('60')) {
             seconds = 0;
-            secondsStr = '0';
+            secondsStr = seconds.toFixed(extraPrecision);
             minutes += 1;
 
             if (minutes == 60) {


### PR DESCRIPTION
The WWT web client currently has a bug with the displayed FOV (noticed by @patudom). The FOV initially shows as 60:00:00, as it should. However, if one zooms in, and then zooms out fully, the FOV shows as 59:59:60. See below:

![format-hms-bug-2022-05-13_14 45 50](https://user-images.githubusercontent.com/14281631/168347854-d8993036-2a9a-473d-bedb-c5c23fb6309c.gif)

This is due to the fact that the angle, upon zooming back out, ultimately lands on the value 59.99999999999999. The implementation of `formatHms` takes floors to determine the second and minute portions of the output. However, while the remaining seconds portion will be strictly less than 60, if the difference is less than the precision (specified by `extraPrecision`), the number of seconds shows as 60. While the example here uses the displayed FOV, this could potentially affect any displayed value formatted using `Util::formatHms`.

This PR fixes the issue by adding a small bit of logic for this case which sets the seconds to zero, adds one to the minutes, and propagates that change up to the hourlike component if necessary. I went with `startsWith` over a double equals check since  (at least in some quick local testing) the speed of `startsWith` is invariant under changes to `extraPrecision`, while `==` slows down as `extraPrecision` is increased. I don't know if there's a more elegant way of doing this than propagating back up the decomposed values after doing the floor functions - I'm not immediately able to think of one, at least.
