### PR TITLE
Initialize layer property sliders with current value

### DIFF
--- a/controllers/modals/DataVizController.js
+++ b/controllers/modals/DataVizController.js
@@ -52,7 +52,6 @@ wwt.controllers.controller('DataVizController', ['$scope', '$rootScope', 'Util',
       return {label: c, type: i};
     });
     l.computeDateDomainRange(0,-1);
-    console.log('compute');
     var none = {label: 'None', index: -1};
     $scope.columns.splice(0, 0, none);
     l.psType = l.get_pointScaleType();
@@ -61,12 +60,21 @@ wwt.controllers.controller('DataVizController', ['$scope', '$rootScope', 'Util',
 
   var sliders = {};
   var initExpSlider = function (sel, prop, initVal) {
-    $scope[prop] = initVal;
+    var value = $scope[prop];
+    if (value == null) {
+      value = l['get_' + prop]();
+      if (value == null) {
+        value = initVal;
+      }
+      $scope[prop] = value;
+    }
     if (sliders[prop]) {
       return;
     }
     setTimeout(function () {
       var bar = $(sel);
+      var pxValue = 4 * Math.round(Math.log2(value)) + 50;
+      bar[0].style.left = pxValue.toString() + 'px';
       var off = parseInt(bar.css('left').replace('px', ''));
       sliders[prop] = new wwt.Move({
         el: bar,


### PR DESCRIPTION
While working with a catalog in the webclient, I noticed a bug with the `DataVizController` (which opens when you right click a layer and select properties). This window has two sliders that control scale factor and time decay. When the window is opened, both sliders are initialized with their default values (1 for scale factor, 16 for time decay), regardless of the current value for the layer.

Changing this to use the current value was a pretty quick fix. The code now checks, in order, the property value in the current scope, the current layer value, and the default, and uses the first one that isn't `null` or `undefined` (I went with `== null` rather than using nullish coalescing since IE doesn't support it). It then translates that into a pixel value for the CSS by just [undoing what happens in onmove](https://github.com/WorldWideTelescope/wwt-web-client/blob/master/controllers/modals/DataVizController.js#L79), with rounding for safety.