### PR TITLE
Update the "front door" email address to hello@worldwidetelescope.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "author": "The AAS WorldWide Telescope Team <wwt@aas.org>",
+  "author": "The WorldWide Telescope Team <hello@worldwidetelescope.org>",
   "bugs": {
-    "email": "wwt@aas.org",
+    "email": "hello@worldwidetelescope.org",
     "url": "https://github.com/WorldWideTelescope/wwt-web-client/issues"
   },
   "buildConfig": {


### PR DESCRIPTION
This is yet another part of the sponsorship migration.

Related pull requests cross-linked at: https://github.com/WorldWideTelescope/worldwidetelescope.github.io/pull/88
