### PR TITLE
Fix issue with constellation-index place sharing

### DIFF
--- a/factories/SearchUtil.js
+++ b/factories/SearchUtil.js
@@ -64,7 +64,7 @@ wwt.app.factory(
       function getPlaceById(id) {
         var deferred = $q.defer();
 
-        searchDataService.getData(all).then(function (d) {
+        searchDataService.getData().then(function (d) {
           var constellationIndex = parseInt(id.split('.')[0]);
           var placeIndex = parseInt(id.split('.')[1]);
           var p = d.Constellations[constellationIndex].places[placeIndex];


### PR DESCRIPTION
This PR is to fix an issue noticed during a meeting yesterday. Currently when we share a place via URL, it can come in the either the form `<collection name>.<index>` or `<constellation index>.<index>`. Sharing places with the first form works fine, but using the constellation index form currently seems broken.

It looks like the reason for this is that we pass a not-defined `all` variable into the search service's `getData` method, which is used to look up these places (and which takes no arguments). This leads to an error and the constellation-based place finding not working. Looking into the git history, this is left over from the old signature of `getData`, which used to take an `all` flag argument. Making these change allows my local webclient to correctly load in places with the constellation-index form.

Share string for a test case: `place=71.79` (an infrared Sagittarius image)