### PR TITLE
Bump VM image in CI to Ubuntu 22.04

### DIFF
--- a/ci/azure-main-build.yml
+++ b/ci/azure-main-build.yml
@@ -4,7 +4,7 @@
 jobs:
 - job: build_linux
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
 
   # Cranko: make and publish release commit
 


### PR DESCRIPTION
The Ubuntu 20.04 image has [been retired on Azure](https://devblogs.microsoft.com/devops/upcoming-updates-for-azure-pipelines-agents-images/), so this PR bumps our CI VM image to use 22.04.