### PR TITLE
Use a different ID for the simple input header close button

### DIFF
--- a/css/modals.less
+++ b/css/modals.less
@@ -245,6 +245,10 @@ body.wwt-webclient-wrapper .wwt-modal.modal.embed-modal{
         }
       }
     }
+
+    #simpleinputclose:hover{
+      cursor: pointer;
+    }
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
         <div class="modal-dialog" id="simpleinput">
           <div class="modal-content">
             <div class="modal-header">
-              <i class="fa fa-close pull-right" id="simpleinputcancel"></i>
+              <i class="fa fa-close pull-right" id="simpleinputclose"></i>
               <h5 id="simpletitle"></h5>
             </div>
 


### PR DESCRIPTION
This is the HTML-side companion to https://github.com/WorldWideTelescope/wwt-webgl-engine/pull/381, and is a part of a more general web client cleanup suggested by #372.

I've also updated the CSS so that the "close" button has a pointer cursor when hovering. This is unrelated to the ID change and is something that is missing on the current web client that I noticed while making this update.

Marking as draft until we see a new web engine release with that PR included.