### PR TITLE
Update workflows to use Ubuntu 24.04

### DIFF
--- a/ci/azure-deployment.yml
+++ b/ci/azure-deployment.yml
@@ -98,7 +98,7 @@ jobs:
 - ${{ if parameters.isRelease }}:
   - job: branch_and_tag
     pool:
-      vmImage: ubuntu-22.04
+      vmImage: ubuntu-24.04
     variables:
     - group: Deployment Credentials
     steps:
@@ -116,7 +116,7 @@ jobs:
   - job: github_releases
     dependsOn: branch_and_tag # otherwise, GitHub creates the tags itself!
     pool:
-      vmImage: ubuntu-22.04
+      vmImage: ubuntu-24.04
     variables:
     - group: Deployment Credentials
     steps:
@@ -132,7 +132,7 @@ jobs:
 
   - job: npm_publish
     pool:
-      vmImage: ubuntu-22.04
+      vmImage: ubuntu-24.04
     variables:
     - group: Deployment Credentials
     steps:

--- a/ci/azure-main-build.yml
+++ b/ci/azure-main-build.yml
@@ -4,7 +4,7 @@
 jobs:
 - job: build_linux
   pool:
-    vmImage: ubuntu-22.04
+    vmImage: ubuntu-24.04
 
   # Cranko: make and publish release commit
 


### PR DESCRIPTION
CI is currently failing - it looks like the latest Cranko wants glibc version 2.38 or 2.39. Our CI runners are using Ubuntu 22.04 which has glibc 2.35 by default. Seems like the easiest thing to do is to upgrade to use Ubuntu 24.04, which uses glibc 2.39, rather than pull back our Cranko version.