### PR TITLE
Security: Potential DOM XSS via unsanitized localization content insertion

### DIFF
--- a/directives/Localize.js
+++ b/directives/Localize.js
@@ -21,10 +21,10 @@
 				var exp = new RegExp(attrs.localize, 'g');
 				var localized = useEn ? attrs.localize : loc.getFromEn(attrs.localize);
 				if (!attrs.locAttrOnly && !attrs.localizeOnly) {
-					if (el.html().indexOf(attrs.localize) != -1 && !useEn) {
-						el.html(el.html().replace(exp, localized));
+					if (el.text().indexOf(attrs.localize) != -1 && !useEn) {
+						el.text(el.text().replace(exp, localized));
 					} else {
-						el.html(localized);
+						el.text(localized);
 					}
 				}
 				if (attrs.localizeAttr || attrs.localizeOnly) {


### PR DESCRIPTION
## Summary

Security: Potential DOM XSS via unsanitized localization content insertion

## Problem

**Severity**: `High` | **File**: `directives/Localize.js:L22`

The `localize` directive writes localization strings directly into the DOM using `el.html(...)`. Localization data is fetched remotely (`catalog.aspx` language packs). If a translation string is compromised or malicious, arbitrary HTML/JS could be injected into the page.

## Solution

Avoid writing untrusted strings with `.html()`. Use text-only insertion (`.text(...)`) for localization values, or sanitize HTML through a strict allowlist sanitizer before insertion. Prefer Angular bindings (`ng-bind`) where possible.

## Changes

- `directives/Localize.js` (modified)