### PR TITLE
Update CI cache purge command

### DIFF
--- a/ci/azure-deployment.yml
+++ b/ci/azure-deployment.yml
@@ -85,7 +85,7 @@ jobs:
       azurePowerShellVersion: 'LatestVersion'
       scriptType: 'inlineScript'
       inline: |
-        Clear-AzCdnEndpointContent `
+        Clear-AzFrontDoorCdnEndpointContent `
           -ProfileName wwt-cdn-01 `
           -ResourceGroupName wwt-web01 `
           -EndpointName wwtweb-prod `


### PR DESCRIPTION
The WWT CDN recently migrated from Azure CDN classic to FrontDoor. As a result, we need to update the command that we use to purge the CDN in our CI process.