### PR TITLE
Allow collapsing of top-level trees

### DIFF
--- a/index.html
+++ b/index.html
@@ -1004,7 +1004,7 @@
 
           <div class="tree" ng-style="{ height: layerManagerHeight()-90 }">
             <div
-              ng-class="sunTree.Sun.collapsed ? 'collapsed' : ''"
+              ng-class="collapsed(node) ? ' collapsed' : ''"
               ng-repeat="(name,node) in sunTree"
               ng-include="'tree-node'">
             </div>

--- a/index.html
+++ b/index.html
@@ -1009,22 +1009,26 @@
               ng-include="'tree-node'">
             </div>
 
-            <i class="fa"
-               ng-class="collapsed(tree) ? 'fa-plus-square-o' : 'fa-minus-square-o'"
-               ng-click="collapse(tree)"></i>
+            <div
+              ng-class="collapsed(tree) ? ' collapsed' : ''"
+            >
+              <i class="fa"
+                 ng-class="collapsed(tree) ? 'fa-plus-square-o' : 'fa-minus-square-o'"
+                 ng-click="collapse(tree)"></i>
 
-            <div class="checkbox" ng-right-click="showMenu(skyNode,$event)" ng-class="{activelayer:skyNode.active}">
-              <label data-ng-class="{checked:tree.checked}" localize="Sky" ng-click="selectionChanged(tree,$event)"
-                     localize-only="title">
-                <input type="checkbox" ng-model="tree.checked"/>
-                <span localize="Sky"></span>
-              </label>
-            </div>
+              <div class="checkbox" ng-right-click="showMenu(skyNode,$event)" ng-class="{activelayer:skyNode.active}">
+                <label data-ng-class="{checked:tree.checked}" localize="Sky" ng-click="selectionChanged(tree,$event)"
+                       localize-only="title">
+                  <input type="checkbox" ng-model="tree.checked"/>
+                  <span localize="Sky"></span>
+                </label>
+              </div>
 
-            <div class="indent"
-                 ng-class="collapsed(node) ? ' collapsed' : ''"
-                 ng-repeat="(name,node) in getChildren(tree)"
-                 ng-include="'tree-node'">
+              <div class="indent"
+                   ng-class="collapsed(node) ? ' collapsed' : ''"
+                   ng-repeat="(name,node) in getChildren(tree)"
+                   ng-include="'tree-node'">
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
This PR follows up on #380 - this time it's the top-level trees in the layer manager that we're allowing to collapse.