### PR TITLE
Allow not invoking child settings when disabling checkboxes; use this for constellation boundaries

### DIFF
--- a/controllers/LayerManagerController.js
+++ b/controllers/LayerManagerController.js
@@ -505,7 +505,7 @@ wwt.controllers.controller(
       };
 
       // enable/disable all child settings based on parent
-      var setChildState = function (node, setChildStates) {
+      var setChildState = function (node, setChildStates=true) {
         if (node.children) {
           $.each(node.children, function (i, child) {
             child.disabled = !node.checked || node.disabled;
@@ -514,7 +514,7 @@ wwt.controllers.controller(
               wwt.wc.settings['set_' + child.action](settingFlag);
             }
 
-            setChildState(child);
+            setChildState(child, setChildStates);
           });
         }
       };

--- a/controllers/LayerManagerController.js
+++ b/controllers/LayerManagerController.js
@@ -231,6 +231,7 @@ wwt.controllers.controller(
                 new treeNode({
                   name: $scope.getFromEn('Constellations'),
                   action: 'constellationsEnabled',
+                  setChildStates: false,
                   children: [
                     new treeNode({
                       name: $scope.getFromEn('Constellation Pictures'),

--- a/controllers/LayerManagerController.js
+++ b/controllers/LayerManagerController.js
@@ -18,6 +18,11 @@ wwt.controllers.controller(
         this.action = args.action;
         this.collapsed = args.collapsed || false;
         this.disabled = false;
+        if (args.setChildStates != undefined) {
+          this.setChildStates = !!args.setChildStates;
+        } else {
+          this.setChildStates = true;
+        }
 
         if (args.mergeWith) {
           this.mergeWith = args.mergeWith;
@@ -242,7 +247,8 @@ wwt.controllers.controller(
                       children: [
                         new treeNode({name: $scope.getFromEn('Focused Only'), action: 'showConstellationSelection'})
                       ],
-                      action: 'showConstellationBoundries'
+                      action: 'showConstellationBoundries',
+                      setChildStates: false,
                     }), new treeNode({
                       name: $scope.getFromEn('Constellation Names'),
                       checked: false,
@@ -495,15 +501,15 @@ wwt.controllers.controller(
           setSticky(node.name, node.action, settingFlag);
         }
 
-        setChildState(node);
+        setChildState(node, node.setChildStates);
       };
 
       // enable/disable all child settings based on parent
-      var setChildState = function (node) {
+      var setChildState = function (node, setChildStates) {
         if (node.children) {
           $.each(node.children, function (i, child) {
             child.disabled = !node.checked || node.disabled;
-            if (child.action && wwt.wc.settings['set_' + child.action]) {
+            if (setChildStates && child.action && wwt.wc.settings['set_' + child.action]) {
               var settingFlag = child.checked && !child.disabled;
               wwt.wc.settings['set_' + child.action](settingFlag);
             }


### PR DESCRIPTION
Currently the webclient disabled child checkboxes when the parent is disabled (at least for some cases - see #384). I think this is nice, but what happens is that not only are the checkboxes disabled, but the actual underlying setting is turned off. I don't think this is always appropriate (and is maybe a bit misleading? as the checkboxes that were selected still show as selected)

This PR adds a `setChildStates` member to the tree node class. If unspecified in the construction arguments, this is true for consistency with current behavior. If this is set to false, child checkboxes are still disabled but the corresponding actions are not invoked.

One use case for this is the constellation boundaries if/when we release https://github.com/WorldWideTelescope/wwt-webgl-engine/pull/390, as this will cause the non-selected constellation boundaries to flash in when turning off boundaries with only the current selection shown. This PR thus sets `setChildStates` to false for that sub-menu.