### PR TITLE
Allow changing constellation item colors

### DIFF
--- a/controllers/LayerManagerController.js
+++ b/controllers/LayerManagerController.js
@@ -421,6 +421,21 @@ wwt.controllers.controller(
             gridName = "equatorialGrid";
           }
           wwtlib.LayerManager.showGridMenu(gridName, event.pageX, event.pageY);
+          return;
+        }
+
+        var constellationOptions = {
+          "Constellation Pictures": "showConstellationPictures",
+          "Constellation Figures": "showConstellationFigures",
+          "Constellation Boundaries": "showConstellationBoundries",  // NB: Typo is intentional
+          "Focused Only": "showConstellationSelection",
+          "Constellation Names": "showConstellationLabels"
+        };
+        var isConstellationOption = node.name in constellationOptions;
+        if (isConstellationOption) {
+          var optionName = node.action.charAt(4).toLowerCase() + node.action.substr(5);
+          wwtlib.LayerManager.showConstellationSettingMenu(optionName, event.pageX, event.pageY);
+          return;
         }
       };
 

--- a/controllers/LayerManagerController.js
+++ b/controllers/LayerManagerController.js
@@ -425,7 +425,6 @@ wwt.controllers.controller(
         }
 
         var constellationOptions = {
-          "Constellation Pictures": "showConstellationPictures",
           "Constellation Figures": "showConstellationFigures",
           "Constellation Boundaries": "showConstellationBoundries",  // NB: Typo is intentional
           "Focused Only": "showConstellationSelection",

--- a/controllers/LayerManagerController.js
+++ b/controllers/LayerManagerController.js
@@ -414,8 +414,8 @@ wwt.controllers.controller(
 
       $scope.showObjectMenu = function (node, event) {
         // TODO: Is there a more robust way to check this?
-        var gridOption = node.name && node.name != "Grids" && node.name.toLowerCase().includes("grid");
-        if (gridOption) {
+        var isGridOption = node.name && node.name != "Grids" && node.name.toLowerCase().includes("grid");
+        if (isGridOption) {
           let gridName = node.action.charAt(4).toLowerCase() + node.action.substr(5);
           if (gridName == "grid") {
             gridName = "equatorialGrid";


### PR DESCRIPTION
This PR is the client-side companion to https://github.com/WorldWideTelescope/wwt-webgl-engine/pull/398 and allows changing the colors of the constellation figures, boundaries, and names in the webclient. This will require a new engine release with that PR merged in.