### PR TITLE
Only update skyball in Sky mode; update on each frame

### DIFF
--- a/factories/Skyball.js
+++ b/factories/Skyball.js
@@ -1,16 +1,10 @@
-﻿wwt.app.factory('Skyball', ['$rootScope', function ($rootScope) {
+wwt.app.factory('Skyball', ['$rootScope', function ($rootScope) {
   var api = {
     init: init
   };
-  var canvas, ctx; 
+  var canvas, ctx;
 
   function draw() {
-    var viewport = arguments[1];
-    //console.log({ viewport: viewport, event: event });
-    if (!viewport.isDirty) {
-      return;
-    }
-
     ctx.clearRect(0, 0, 100, 100);
     var sphereSize = $('#skyball').height();
     var radius = sphereSize / 2;
@@ -42,7 +36,6 @@
       ctx.closePath();
       ctx.stroke();
     });
-    //console.log({coordx: coords[0].x, coordy: coords[0].y});
 
     ctx.beginPath();
     ctx.lineWidth = '1';
@@ -77,9 +70,13 @@
       });
     skyball.append(canvas);
     ctx = canvas.get(0).getContext('2d');
-    $rootScope.$on('viewportchange', draw);
+    $rootScope.$on('viewportchange', function (_event, viewport) {
+      if (viewport.isDirty && wwtlib.WWTControl.singleton.renderType == wwtlib.ImageSetType.sky) {
+        draw();
+      }
+    });
 
-    draw(null, {isDirty: true});
+    draw();
 
   }
 

--- a/factories/Util.js
+++ b/factories/Util.js
@@ -422,13 +422,12 @@ wwt.app.factory(
 
       $(document).on('keyup', keyHandler);
 
-      var dirtyInterval,
-          viewport = {
-            isDirty: false,
-            RA: 0,
-            Dec: 0,
-            Fov: 60
-          };
+      var viewport = {
+        isDirty: false,
+        RA: 0,
+        Dec: 0,
+        Fov: 60
+      };
 
       function trackViewportChanges() {
         viewport = {
@@ -456,7 +455,7 @@ wwt.app.factory(
           viewport.init = false;
 
 
-          dirtyInterval = setInterval(dirtyViewport, 250);
+          wwtlib.WWTControl.scriptInterface.add_on_frame(dirtyViewport);
         });
       }
 

--- a/index.html
+++ b/index.html
@@ -1077,7 +1077,7 @@
               <i class="fa fa-share-alt"></i>
             </a>
 
-            <div class="left" ng-show="lookAt != 'SolarSystem'">
+            <div class="left" ng-show="lookAt == 'Sky'">
               <p localize="N"></p>
               <div class="sphere" id="skyball">
                 <div class="v-ellipse"></div>


### PR DESCRIPTION
This PR fixes #389 by changing the skyball to only update if we're actually in Sky mode. Additionally, this PR utilizes the engine's new frame callback functionality to update whether the viewport is dirty on each frame (currently it updates on a 250ms interval). At least to me, this leads to the skyball updates feeling smoother and more responsive.

As far as only drawing the skyball in Sky mode: I originally tried passing in the scope and checking `scope.lookAt`, but this actually updates before WWT draws its next frame. When switching to sky mode from another mode, this can lead to the Skyball being inaccurate  until the user changes the viewport. Thus I opted to check the render type directly instead.