### PR TITLE
Remove sign-in and sign-out buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -417,13 +417,7 @@
         <!-- Very top ribbon -->
 
         <div id="ribbon">
-          <span class="pull-right" ng-controller="LoginController">
-            <a class="btn pull-right" ng-click="login()" ng-show="msLiveOAuthAppId && msLiveOAuthAppId.length && !loggedIn">
-              <span localize="Sign In"></span>
-            </a>
-            <a class="btn pull-right" ng-click="logout()" ng-show="msLiveOAuthAppId && msLiveOAuthAppId.length && loggedIn">
-              <span localize="Sign Out"></span>
-            </a>
+          <span class="pull-right">
             <a class="btn pull-right" href="https://numfocus.org/donate-for-worldwide-telescope" target="_blank">
               <span>Support WWT ❤️</span>
             </a>


### PR DESCRIPTION
The webclient sign-in and sign-out buttons are related to WWT Communities, which is no longer supported (the relevant functionality has been removed from the core server). This means that any sign-in attempt will fail and give and error screen, so this PR removes those buttons from the interface.