### PR TITLE
Fix issues with skyball

### DIFF
--- a/controllers/MainController.js
+++ b/controllers/MainController.js
@@ -160,6 +160,8 @@ wwt.controllers.controller(
         var w = $window.innerWidth;
         var h = $window.innerHeight;
 
+        var was_mobile = $rootScope.is_mobile;
+
         // I'm not at all confident in the robustness of this logic, but it's what we've been using.
         $rootScope.is_mobile = (h < 600 || w < 700) && (h < 900 && w < 600);
 
@@ -180,6 +182,10 @@ wwt.controllers.controller(
           wwt_div
             .height(h)
             .width(w);
+        }
+
+        if ($rootScope.is_mobile != was_mobile) {
+          $rootScope.$broadcast('mobilechange', $rootScope.is_mobile);
         }
       }
 

--- a/factories/Skyball.js
+++ b/factories/Skyball.js
@@ -60,6 +60,11 @@ wwt.app.factory('Skyball', ['$rootScope', function ($rootScope) {
       return;
     }
 
+    if (canvas) {
+      skyball.remove(canvas);
+      canvas.remove();
+      canvas = null;
+    }
     canvas = $('<canvas></canvas>')
       .css({
         position: 'absolute',
@@ -75,6 +80,12 @@ wwt.app.factory('Skyball', ['$rootScope', function ($rootScope) {
         draw();
       }
     });
+    $rootScope.$on('mobilechange', function (_event) {
+      requestAnimationFrame(() => requestAnimationFrame(() => init()));
+    });
+    $(window).on('resize', function () {
+      draw();
+    });
 
     draw();
 
@@ -84,8 +95,6 @@ wwt.app.factory('Skyball', ['$rootScope', function ($rootScope) {
     this.x = x;
     this.y = y;
   }
-
-  //console.log('skyball');
 
   return api;
 }]);


### PR DESCRIPTION
This PR fixes #391 and #394:

- For #391, this PR makes the skyball redraw each time the window is resized.
- To handle #394, this adds a new `mobilechange` event which is broadcast each time we switch between desktop/mobile UIs. Since the skyball in the UI is now going to be a different element, we re-initialize the skyball on a UI type change, making sure to delete the old canvas as well.