### PR TITLE
Remove forums link in main menu

### DIFF
--- a/controllers/MainController.js
+++ b/controllers/MainController.js
@@ -370,7 +370,6 @@ wwt.controllers.controller(
             button: 'rbnHome',
             menu: {
               'Main Website': [util.nav_user, '/home'],
-              'User Forums': [function () { window.open('https://wwt-forum.org/'); }],
               'Contributor Hub': [function () { window.open('https://worldwidetelescope.github.io/'); }],
               'GitHub Home': [function () { window.open('https://github.com/WorldWideTelescope'); }],
               'Sign up for Newsletter': [function () { window.open('https://bit.ly/wwt-signup'); }],

--- a/index.html
+++ b/index.html
@@ -240,10 +240,6 @@
                 </li>
 
                 <li>
-                  <a ng-click="gotoPage('https://wwt-forum.org/')" target="_blank" localize="WWT User Forums"></a>
-                </li>
-
-                <li>
                   <a ng-click="gotoPage('https://worldwidetelescope.github.io')" target="_blank" localize="Contributor Hub"></a>
                 </li>
 


### PR DESCRIPTION
We're planning on winding down the WWT forum, and a good way to start that is to reduce visibility by removing the forum links from the webclient UI.